### PR TITLE
:sparkles: Add NorthstarProton compatibility tool

### DIFF
--- a/src/models/tool.vala
+++ b/src/models/tool.vala
@@ -31,6 +31,7 @@ namespace ProtonPlus.Models {
             tools[2] = new Tool ("Luxtorpeda", "Luxtorpeda provides Linux-native game engines for specific Windows-only games.", "https://api.github.com/repos/luxtorpeda-dev/luxtorpeda/releases", 0);
             tools[3] = new Tool ("Boxtron", "Steam Play compatibility tool to run DOS games using native Linux DOSBox.", "https://api.github.com/repos/dreamer/boxtron/releases", 0);
             tools[4] = new Tool ("Roberta", "Steam Play compatibility tool to run adventure games using native Linux ScummVM.", "https://api.github.com/repos/dreamer/roberta/releases", 1);
+            tools[5] = new Tool ("NorthstarProton", "Custom Proton build for running the Northstar client for Titanfall 2.", "https://api.github.com/repos/cyrv6737/NorthstarProton/releases", 0);
 
             return tools;
         }

--- a/src/models/tool.vala
+++ b/src/models/tool.vala
@@ -24,7 +24,7 @@ namespace ProtonPlus.Models {
         }
 
         public static Tool[] Steam () {
-            var tools = new Tool[5];
+            var tools = new Tool[6];
 
             tools[0] = new Tool ("GE-Proton", "Steam compatibility tool for running Windows games with improvements over Valve's default Proton. Use this when you don't know what to choose.", "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases", 1);
             tools[1] = new Tool ("Proton Tkg", "Custom Proton build for running Windows games, built with the Wine-tkg build system.", "https://api.github.com/repos/Frogging-Family/wine-tkg-git/releases", 1);


### PR DESCRIPTION
### Category
Feature

### Overview
Adds NorthstarProton to the list of Steam compatibility tools. NorthstarProton is a custom build of Proton Tkg intended for use (only) with Titanfall 2 and the Northstar game client.

https://github.com/R2Northstar/Northstar
https://github.com/cyrv6737/NorthstarProton
https://r2northstar.gitbook.io/r2northstar-wiki/using-northstar/playing-on-linux

ProtonUp-Qt has some interest in offering the same and an open issue: https://github.com/DavidoTek/ProtonUp-Qt/issues/115
