### PR TITLE
Correct desktop file category

### DIFF
--- a/data/com.vysp3r.ProtonPlus.desktop
+++ b/data/com.vysp3r.ProtonPlus.desktop
@@ -4,5 +4,5 @@ Exec=protonplus
 Icon=com.vysp3r.ProtonPlus
 Terminal=false
 Type=Application
-Categories=Games;
+Categories=Game;
 StartupNotify=true


### PR DESCRIPTION
```
❯ desktop-file-validate com.vysp3r.ProtonPlus.desktop
com.vysp3r.ProtonPlus.desktop: error: value "Games;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Games"; values extending the format should start with "X-"
com.vysp3r.ProtonPlus.desktop: hint: value "Games;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
```

EDIT: Sorry, missed the template. The above is self-explanatory.



