### PR TITLE
:bug: Fix window always being able to be closed

### DIFF
--- a/po/com.vysp3r.ProtonPlus.pot
+++ b/po/com.vysp3r.ProtonPlus.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,12 +17,16 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -125,35 +129,35 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 msgid "Download started...\n"
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 msgid "Download done...\n"
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 msgid "Extraction started...\n"
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 msgid "Extraction done...\n"
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -1,17 +1,21 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "Language: es_ES\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -115,39 +119,39 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "Descargando..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "Descargando..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "Extrayendo..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "Extrayendo..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,17 +1,21 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "Language: fr_CA\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -115,39 +119,39 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "En téléchargement..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "En téléchargement..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "En extraction..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "En extraction..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: yukidream <mashirokuratamorfo@gmail.com>\n"
 "Language-Team: \n"
@@ -12,12 +12,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -121,39 +125,39 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "Mengunduh..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "Mengunduh..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "Mengekstrak..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "Mengekstrak..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -1,17 +1,21 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "Language: it_IT\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -115,39 +119,39 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "Scaricamento in corso..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "Scaricamento in corso..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "Estrazione in corso..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "Estrazione in corso..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,17 +1,21 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "Language: pt_BR\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -115,39 +119,39 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "Baixando..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "Baixando..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "Extraindo..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "Extraindo..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,17 +1,21 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "Language: ru_RU\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -116,39 +120,39 @@ msgstr "Отменено!"
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "Скачивается..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "Скачивается..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "Распаковывается..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "Распаковывается..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-05 11:35-0400\n"
+"POT-Creation-Date: 2023-04-05 12:12-0400\n"
 "PO-Revision-Date: 2023-01-11 22:36+0800\n"
 "Last-Translator: neovali <valigarmanda55@gmail.com>\n"
 "Language-Team: Chinese - China\n"
@@ -15,12 +15,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Gtranslator 42.0\n"
 
-#: src/Windows/Main.vala:63
+#: src/Windows/Main.vala:69
 msgid "A simple Wine and Proton-based compatiblity tools manager for GNOME"
 msgstr ""
 
-#: src/Windows/Main.vala:70
+#: src/Windows/Main.vala:76
 msgid "Special thanks to"
+msgstr ""
+
+#: src/Windows/Main.vala:89
+msgid "You cannot close the window while a tool is installing"
 msgstr ""
 
 #.
@@ -124,39 +128,39 @@ msgstr ""
 msgid "Cancelled the install..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:76
+#: src/Windows/Tools/ReleaseInstaller.vala:79
 msgid "You cannot cancel the operation for tools using Github Actions."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:77
+#: src/Windows/Tools/ReleaseInstaller.vala:80
 #, fuzzy
 msgid "Download started...\n"
 msgstr "下载中..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:115
+#: src/Windows/Tools/ReleaseInstaller.vala:118
 #, fuzzy
 msgid "Download done...\n"
 msgstr "下载中..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:126
+#: src/Windows/Tools/ReleaseInstaller.vala:129
 #, fuzzy
 msgid "Extraction started...\n"
 msgstr "解压中..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:129
+#: src/Windows/Tools/ReleaseInstaller.vala:132
 msgid "You cannot cancel the operation while it's extracting."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:160
+#: src/Windows/Tools/ReleaseInstaller.vala:163
 msgid "There was an error while extracting..."
 msgstr ""
 
-#: src/Windows/Tools/ReleaseInstaller.vala:170
+#: src/Windows/Tools/ReleaseInstaller.vala:173
 #, fuzzy
 msgid "Extraction done...\n"
 msgstr "解压中..."
 
-#: src/Windows/Tools/ReleaseInstaller.vala:172
+#: src/Windows/Tools/ReleaseInstaller.vala:175
 msgid "You cannot cancel the operation when it's already completed."
 msgstr ""
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -3,6 +3,8 @@ using Utils.Constants;
 public class ProtonPlus : Adw.Application {
     static GLib.Once<ProtonPlus> _instance;
 
+    public Windows.Main mainWindow;
+
     public static unowned ProtonPlus get_instance () {
         return _instance.once (() => { return new ProtonPlus (); });
     }
@@ -32,14 +34,14 @@ public class ProtonPlus : Adw.Application {
                                                    Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         //
-        var window = new Windows.Main (this);
+        mainWindow = new Windows.Main (this);
 
         //
         if (GLib.Environment.get_variable ("DESKTOP_SESSION") == "gamescope-wayland") {
-            window.fullscreen ();
+            mainWindow.fullscreen ();
         }
 
         //
-        window.show ();
+        mainWindow.show ();
     }
 }

--- a/src/Windows/Main.vala
+++ b/src/Windows/Main.vala
@@ -1,8 +1,14 @@
 namespace Windows {
     public class Main : Adw.ApplicationWindow {
+        public bool installing;
+
         Gtk.Notebook notebook;
+        Adw.ToastOverlay toastOverlay;
 
         public Main (Adw.Application app) {
+            //
+            installing = false;
+
             //
             ActionEntry[] action_entries = {
                 { "preferences", on_preferences_action },
@@ -20,7 +26,7 @@ namespace Windows {
             set_size_request (900, 600);
 
             //
-            var toastOverlay = new Adw.ToastOverlay ();
+            toastOverlay = new Adw.ToastOverlay ();
 
             //
             notebook = new Gtk.Notebook ();
@@ -76,6 +82,15 @@ namespace Windows {
 
         void on_preferences_action () {
             notebook.set_current_page (1);
+        }
+
+        public override bool close_request () {
+            if (installing) {
+                var toast = new Adw.Toast (_("You cannot close the window while a tool is installing"));
+                toastOverlay.add_toast (toast);
+            }
+
+            return installing;
         }
     }
 }

--- a/src/Windows/Tools/ReleaseInstaller.vala
+++ b/src/Windows/Tools/ReleaseInstaller.vala
@@ -66,10 +66,13 @@ namespace Windows.Tools {
             btnCancel.set_sensitive (false);
             btnBack.set_sensitive (true);
             release = null;
+            ProtonPlus.get_instance ().mainWindow.installing = false;
         }
 
         public void Download (Models.Release release) {
             this.release = release;
+
+            ProtonPlus.get_instance ().mainWindow.installing = true;
 
             btnBack.set_sensitive (false);
             btnCancel.set_sensitive (!release.Tool.IsUsingGithubActions);

--- a/src/Windows/Tools/ToolInfo.vala
+++ b/src/Windows/Tools/ToolInfo.vala
@@ -75,7 +75,7 @@ namespace Windows.Tools {
                         spinner.stop ();
                         spinner.set_visible (false);
 
-                        var toast = new Adw.Toast (_("There was an error while fetching data from the GitHub API."));
+                        var toast = new Adw.Toast (_("There was an error while fetching data from the GitHub API"));
                         toast.set_button_label (_("Learn more"));
                         toast.set_timeout (15000);
                         toast.button_clicked.connect (() => {


### PR DESCRIPTION
I added a check so that when you're installing a tool, you cannot close the window until you cancel or wait for the installation to be done.

