### PR TITLE
:bug: Fix Bottles icon missing

### DIFF
--- a/src/launchers/bottles.vala
+++ b/src/launchers/bottles.vala
@@ -20,7 +20,7 @@ namespace ProtonPlus.Launchers {
             var launcher = new Models.Launcher (
                                                 "Bottles",
                                                 "System",
-                                                "/com/vysp3r/ProtonPlus/images/bottles.png",
+                                                "/com/vysp3r/ProtonPlus/bottles.png",
                                                 directories
             );
 


### PR DESCRIPTION
The path to the icon was invalid for the system version of Bottles so I just fixed the path.


