### PR TITLE
Use PNG app icons instead of SVG

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -8,9 +8,10 @@ subdir('icons')
 subdir('images')
 
 #
-install_data(
-      join_paths('logo', 'com.vysp3r.ProtonPlus.svg'),
-      install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'icons', 'hicolor', 'scalable', 'apps')
+install_subdir(
+                       join_paths('logo', 'icons'),
+          install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'icons'),
+      strip_directory: true
 )
 
 #


### PR DESCRIPTION
This fixes the issue that KDE is awful at rendering SVG icons. We now use PNG for every desktop environment instead.

Closes #260 