### PR TITLE
data/meson.build: modify AppData validation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -33,7 +33,7 @@ appstream_file = i18n.merge_file(
 
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
-  test('Validate appstream file', appstream_util, args: ['validate', appstream_file])
+  test('Validate appstream file', appstream_util, args: ['validate-relax', '--nonet', appstream_file])
 endif
 
 install_data('com.vysp3r.ProtonPlus.gschema.xml',


### PR DESCRIPTION
### Category
Test

### Overview

I updated the [manual tests](https://github.com/wehagy/rpm-protonplus/commit/a4a41c642fb376138f0b585c45c04789016f2254#diff-766e7c44a8bbb19963b5056d0daf01153a736d67628ea1b00f885eb196082f60R129-L130) of my RPM build to use the [upstream tests](https://github.com/Vysp3r/ProtonPlus/blob/97e32ebe10f5d4f3ac94196b73c954078b1c6b18/data/meson.build#L34-L37), but I am encountering errors when trying to build the RPM in Copr.

This patch resolves the test failures and ensures compliance with Fedora packaging guidelines.

Additionally, this is a version of my patch for packaging in Copr for Fedora [fix-appstream-util-test.patch](https://github.com/wehagy/rpm-protonplus/blob/protonplus-next/fix-appstream-util-test.patch).

### New Vars

- change the flag 'validate' to 'validate-relax'
- Add the '--nonet' flag
- ensure compliance with Fedora packaging guidelines

Reference:
https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/#_app_data_validate_usage

