### PR TITLE
i18n: Add missing translations, fix placeholder ordering, and relocate punctuation

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -84,3 +84,4 @@ src/utils/parser.vala
 src/utils/web.vala
 src/utils/system.vala
 src/main.vala
+data/ui/gtk/help-overlay.ui

--- a/po/com.vysp3r.ProtonPlus.pot
+++ b/po/com.vysp3r.ProtonPlus.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-30 16:42-0400\n"
+"POT-Creation-Date: 2025-07-02 00:26+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,6 +56,15 @@ msgstr ""
 
 #: src/widgets/window.vala:60
 msgid "Main Menu"
+msgstr ""
+
+#: src/widgets/window.vala:65 src/models/launchers/bottles.vala:29
+#: src/models/launchers/steam.vala:42
+msgid "Runners"
+msgstr ""
+
+#: src/widgets/window.vala:66
+msgid "Games"
 msgstr ""
 
 #: src/widgets/runners/description-dialog.vala:14
@@ -290,7 +299,8 @@ msgid "Unsuported launcher"
 msgstr ""
 
 #: src/widgets/games/games-box.vala:170
-msgid "is currently not supported."
+#, c-format
+msgid "%s is currently not supported."
 msgstr ""
 
 #: src/widgets/games/games-box.vala:170
@@ -330,11 +340,12 @@ msgid "Mass edit"
 msgstr ""
 
 #: src/widgets/games/mass-edit-dialog.vala:20
-msgid "game selected"
+msgid "1 game selected"
 msgstr ""
 
 #: src/widgets/games/mass-edit-dialog.vala:20
-msgid "games selected"
+#, c-format
+msgid "%u games selected"
 msgstr ""
 
 #: src/widgets/games/mass-edit-dialog.vala:22
@@ -381,7 +392,7 @@ msgstr ""
 #: src/widgets/games/mass-edit-dialog.vala:147
 msgid ""
 "When trying to change the compatibility tool/launch options of the selected "
-"games an error occured for the following games"
+"games an error occured for the following games:"
 msgstr ""
 
 #: src/widgets/games/shortcut-button.vala:23
@@ -503,10 +514,6 @@ msgstr ""
 msgid "When trying to change the compatibility tool of %s an error occured."
 msgstr ""
 
-#: src/models/launchers/bottles.vala:29 src/models/launchers/steam.vala:42
-msgid "Runners"
-msgstr ""
-
 #: src/models/launchers/bottles.vala:29 src/models/launchers/hgl.vala:32
 #: src/models/launchers/lutris.vala:36
 msgid "Compatibility tools for running Windows software on Linux."
@@ -602,4 +609,19 @@ msgstr ""
 msgid ""
 "Steam tool for easy, graphical configuration of your other compatibility "
 "tools for both Windows games and native Linux games."
+msgstr ""
+
+#: data/ui/gtk/help-overlay.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: data/ui/gtk/help-overlay.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr ""
+
+#: data/ui/gtk/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-30 16:42-0400\n"
-"PO-Revision-Date: 2025-06-30 19:35+0800\n"
+"POT-Creation-Date: 2025-07-02 00:26+0800\n"
+"PO-Revision-Date: 2025-07-02 00:32+0800\n"
 "Last-Translator: nick.exe <nick.exe@gmail.com>\n"
 "Language-Team: CodeBay.IN\n"
 "Language: zh_TW\n"
@@ -57,6 +57,15 @@ msgstr "關於 ProtonPlus(_A)"
 #: src/widgets/window.vala:60
 msgid "Main Menu"
 msgstr "主選單"
+
+#: src/widgets/window.vala:65 src/models/launchers/bottles.vala:29
+#: src/models/launchers/steam.vala:42
+msgid "Runners"
+msgstr "運行器"
+
+#: src/widgets/window.vala:66
+msgid "Games"
+msgstr "遊戲庫"
 
 #: src/widgets/runners/description-dialog.vala:14
 msgid "More information"
@@ -290,8 +299,9 @@ msgid "Unsuported launcher"
 msgstr "未支援的啟動器"
 
 #: src/widgets/games/games-box.vala:170
-msgid "is currently not supported."
-msgstr "目前尚未支援。"
+#, c-format
+msgid "%s is currently not supported."
+msgstr "目前尚未支援 %s。"
 
 #: src/widgets/games/games-box.vala:170
 msgid ""
@@ -330,12 +340,13 @@ msgid "Mass edit"
 msgstr "批量編輯"
 
 #: src/widgets/games/mass-edit-dialog.vala:20
-msgid "game selected"
-msgstr "款遊戲已選取"
+msgid "1 game selected"
+msgstr "已選取 1 款遊戲"
 
 #: src/widgets/games/mass-edit-dialog.vala:20
-msgid "games selected"
-msgstr "款遊戲已選取"
+#, c-format
+msgid "%u games selected"
+msgstr "已選取 %u 款遊戲"
 
 #: src/widgets/games/mass-edit-dialog.vala:22
 #: src/widgets/games/launch-options-dialog.vala:14
@@ -381,8 +392,8 @@ msgstr "請啟用要在批量編輯中涵蓋的所有選項。"
 #: src/widgets/games/mass-edit-dialog.vala:147
 msgid ""
 "When trying to change the compatibility tool/launch options of the selected "
-"games an error occured for the following games"
-msgstr "嘗試變更所選遊戲的相容性工具/啟動選項時，下列遊戲發生錯誤"
+"games an error occured for the following games:"
+msgstr "嘗試變更所選遊戲的相容性工具/啟動選項時，下列遊戲發生錯誤："
 
 #: src/widgets/games/shortcut-button.vala:23
 #: src/widgets/games/shortcut-button.vala:28
@@ -503,10 +514,6 @@ msgstr "選擇所需的相容性工具"
 msgid "When trying to change the compatibility tool of %s an error occured."
 msgstr "嘗試變更 %s 的相容性工具時發生錯誤。"
 
-#: src/models/launchers/bottles.vala:29 src/models/launchers/steam.vala:42
-msgid "Runners"
-msgstr "運行器"
-
 #: src/models/launchers/bottles.vala:29 src/models/launchers/hgl.vala:32
 #: src/models/launchers/lutris.vala:36
 msgid "Compatibility tools for running Windows software on Linux."
@@ -614,6 +621,21 @@ msgid ""
 msgstr ""
 "讓您能以圖形介面輕鬆設定的 Steam 工具，專門調整用於 Windows 遊戲和原生 Linux "
 "遊戲的各種相容性工具。"
+
+#: data/ui/gtk/help-overlay.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr "一般"
+
+#: data/ui/gtk/help-overlay.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "顯示捷徑鍵"
+
+#: data/ui/gtk/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "離開"
 
 #~ msgid "Library"
 #~ msgstr "遊戲庫"

--- a/src/widgets/games/games-box.vala
+++ b/src/widgets/games/games-box.vala
@@ -167,11 +167,11 @@ namespace ProtonPlus.Widgets {
 				}
 			} else {
 				invalid = true;
-				show_status_box (launcher.icon_path, _("Unsuported launcher"), "%s %s\n%s".printf(launcher.title, _("is currently not supported."), _("If you want me to speed up the development make sure to show your support!")), true);
+				show_status_box(launcher.icon_path, _("Unsuported launcher"), "%s\n%s".printf(_("%s is currently not supported.").printf(launcher.title), _("If you want me to speed up the development make sure to show your support!")), true);
 			}
 		}
 
-		void show_normal () {
+		void show_normal() {
 			error = false;
 
 			flow_box.set_visible(true);
@@ -180,7 +180,7 @@ namespace ProtonPlus.Widgets {
 			status_page.set_visible (false);
 		}
 
-		void show_status_box (string icon, string title, string description, bool image = false) {
+		void show_status_box(string icon, string title, string description, bool image = false) {
 			flow_box.set_visible(false);
 			headered_list_box.set_visible(false);
 			warning_label.set_visible(false);

--- a/src/widgets/games/mass-edit-dialog.vala
+++ b/src/widgets/games/mass-edit-dialog.vala
@@ -17,7 +17,7 @@ namespace ProtonPlus.Widgets {
 		public MassEditDialog(GameRow[] rows, ListStore model, Gtk.PropertyExpression expression) {
 			this.rows = rows;
 
-			window_title = new Adw.WindowTitle(_("Mass edit"), "%u %s".printf(rows.length, rows.length == 1 ? _("game selected") : _("games selected")));
+			window_title = new Adw.WindowTitle(_("Mass edit"), rows.length == 1 ? _("1 game selected") : _("%u games selected").printf(rows.length));
 
 			apply_button = new Gtk.Button.with_label(_("Apply"));
 			apply_button.set_tooltip_text(_("Apply the current modifications"));
@@ -144,7 +144,7 @@ namespace ProtonPlus.Widgets {
 						names += "\n";
 				}
 
-				var dialog = new Adw.AlertDialog(_("Error"), "%s:\n\n%s\n\n%s".printf(_("When trying to change the compatibility tool/launch options of the selected games an error occured for the following games"), names, _("Please report this issue on GitHub.")));
+				var dialog = new Adw.AlertDialog(_("Error"), "%s\n\n%s\n\n%s".printf(_("When trying to change the compatibility tool/launch options of the selected games an error occured for the following games:"), names, _("Please report this issue on GitHub.")));
 				dialog.add_response("ok", "OK");
 				dialog.present(Application.window);
 			}

--- a/src/widgets/window.vala
+++ b/src/widgets/window.vala
@@ -62,8 +62,8 @@ namespace ProtonPlus.Widgets {
 			menu_button.set_menu_model (menu);
 
 			view_stack = new Adw.ViewStack ();
-			view_stack.add_titled_with_icon (runners_box, "runners", "Runners", "preferences-system-symbolic");
-			view_stack.add_titled_with_icon (games_box, "games", "Games", "applications-games-symbolic");
+			view_stack.add_titled_with_icon (runners_box, "runners", _("Runners"), "preferences-system-symbolic");
+			view_stack.add_titled_with_icon (games_box, "games", _("Games"), "applications-games-symbolic");
 			view_stack.notify["visible-child-name"].connect(view_stack_visible_child_name_changed);
 
 			view_switcher = new Adw.ViewSwitcher ();


### PR DESCRIPTION
### Category
> Bugfix

### Overview
>- Filled in missing or incomplete entries in PO files
>- Reordered format placeholders (%s, %u) to match grammar rules in multiple languages
>- Moved hardcoded punctuation (e.g. colons, commas) into translatable strings
>- Update Traditional Chinese translation