### PR TITLE
Fix translation crash on empty string

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-07-03 19:03-0400\n"
-"PO-Revision-Date: 2025-07-02 00:32+0800\n"
+"PO-Revision-Date: 2025-07-04 20:18+0800\n"
 "Last-Translator: nick.exe <nick.exe@gmail.com>\n"
 "Language-Team: CodeBay.IN\n"
 "Language: zh_TW\n"
@@ -58,13 +58,12 @@ msgid "Games"
 msgstr "遊戲庫"
 
 #: src/widgets/window.vala:93
-#, fuzzy
 msgid "An error ocurred"
 msgstr "發生錯誤"
 
 #: src/widgets/window.vala:93
 msgid "There was an error when trying to load the launchers."
-msgstr ""
+msgstr "嘗試載入啟動器時發生錯誤。"
 
 #: src/widgets/window.vala:93 src/widgets/runners/remove-dialog.vala:49
 #: src/widgets/runners/install-dialog.vala:54
@@ -563,22 +562,20 @@ msgid "Custom Proton build for running Windows games, based on Wine-tkg."
 msgstr "基於 Wine-tkg 的，運行 Windows 遊戲的自訂 Proton 建構版本。"
 
 #: src/main.vala:23
-#, fuzzy
 msgid ""
 "Steam compatibility tool based on Proton-GE with modifications for very old "
 "GPUs, with DXVK."
 msgstr ""
-"基於 Proton-GE 的 Steam 相容性工具，包含對非常舊的 GPU 進行的修改，並包含 "
-"%s。"
+"基於 Proton-GE 的 Steam 相容性工具，包含對非常舊的 GPU 進行的修改，以及 "
+"DXVK。"
 
 #: src/main.vala:24
-#, fuzzy
 msgid ""
 "Steam compatibility tool based on Proton-GE with modifications for very old "
 "GPUs, with DXVK-Async."
 msgstr ""
-"基於 Proton-GE 的 Steam 相容性工具，包含對非常舊的 GPU 進行的修改，並包含 "
-"%s。"
+"基於 Proton-GE 的 Steam 相容性工具，包含對非常舊的 GPU 進行的修改，以及 DXVK-"
+"Async。"
 
 #: src/main.vala:25
 msgid ""
@@ -632,12 +629,11 @@ msgstr "適用於 Linux/Wine 的，基於 Vulkan 的 Direct3D 8、9、10 和 11 
 
 #: src/main.vala:36
 msgid "DXVK Builds that work with pre-Vulkan 1.3 versions"
-msgstr "適用於 Vulkan 1.3 之前的 DXVK 建構版本。"
+msgstr "適用於 Vulkan 1.3 之前版本的 DXVK 建構版本。"
 
 #: src/main.vala:37
-#, fuzzy
 msgid "DXVK Async Builds that work with pre-Vulkan 1.3 versions"
-msgstr "適用於 Vulkan 1.3 之前的 DXVK 建構版本。"
+msgstr "適用於 Vulkan 1.3 之前版本的 DXVK-Async 建構版本。"
 
 #: src/main.vala:38
 msgid ""

--- a/src/meson.build
+++ b/src/meson.build
@@ -77,6 +77,7 @@ protonplus_sources = files(
   'utils/web.vala',
   'utils/parser.vala',
   'utils/system.vala',
+  'utils/i18n.vala',
 )
 
 protonplus_deps = [

--- a/src/models/launcher.vala
+++ b/src/models/launcher.vala
@@ -205,7 +205,7 @@ namespace ProtonPlus.Models {
 					if (json_group_item == null)
 						return false;
 					
-					groups[i] = new Group (json_launcher_group_item.title, json_group_item.description, json_launcher_group_item.directory, launcher);
+					groups[i] = new Group (json_launcher_group_item.title, Utils.safe_translate(json_group_item.description), json_launcher_group_item.directory, launcher);
             		
 					groups[i].runners = new List<Runner> ();
 
@@ -417,7 +417,7 @@ namespace ProtonPlus.Models {
 
 			if (runner != null) {
 				runner.title = json_runner_item.title;
-				runner.description = _(json_runner_item.description);
+				runner.description = Utils.safe_translate(json_runner_item.description);
 				runner.endpoint = json_runner_item.endpoint;
 				runner.asset_position = json_runner_item.asset_position;
 				runner.directory_name_format = yield get_directory_name_format_from_array(json_runner_item.directory_name_formats, group.launcher.title);

--- a/src/utils/i18n.vala
+++ b/src/utils/i18n.vala
@@ -1,0 +1,5 @@
+namespace ProtonPlus.Utils {
+    public static string safe_translate(string? str) {
+		return (str != null && str != "") ? _(str) : "";
+	}
+}


### PR DESCRIPTION
When the JSON description is an empty string, passing it to _() causes issues, so a check is required beforehand.