### PR TITLE
Fix issue with incorrectly identifying Steam shortcut

### DIFF
--- a/src/models/vdf/shortcut.vala
+++ b/src/models/vdf/shortcut.vala
@@ -105,11 +105,11 @@ namespace ProtonPlus.Models.VDF {
             VDF.Shortcut shortcut = {};
             foreach (var entry in nodes.entries) {
                 if (entry.key.contains("shortcuts.") && !entry.key.contains(".tags")) {
-                    if (entry.value.get("AppName").get_string() == name) {
+                    if (entry.value.get("appname").get_string() == name) {
                         shortcut.AppID = entry.value.get("appid").get_int32();
                         shortcut.AllowDesktopConfig = entry.value.get("AllowDesktopConfig").get_int32() > 0 ? true : false;
                         shortcut.AllowOverlay = entry.value.get("AllowOverlay").get_int32() > 0 ? true : false;
-                        shortcut.AppName = entry.value.get("AppName").get_string();
+                        shortcut.AppName = entry.value.get("appname").get_string();
                         shortcut.Devkit = entry.value.get("Devkit").get_int32();
                         shortcut.DevkitGameID = entry.value.get("DevkitGameID").get_string();
                         shortcut.DevkitOverrideAppID = entry.value.get("DevkitOverrideAppID").get_int32();
@@ -131,7 +131,7 @@ namespace ProtonPlus.Models.VDF {
         public void replace_shortcut_by_name(string name, VDF.Shortcut shortcut) {
             foreach (var entry in nodes.entries) {
                 if (entry.key.contains("shortcuts.") && !entry.key.contains(".tags")) {
-                    if (entry.value.get("AppName").get_string() == name) {
+                    if (entry.value.get("appname").get_string() == name) {
                         write_shortcut_on_node(entry.value, shortcut);
                         return;
                     }
@@ -142,7 +142,7 @@ namespace ProtonPlus.Models.VDF {
         public int get_shortcut_id_by_name(string name) throws Error {
             foreach (var entry in nodes.entries) {
                 if (entry.key.contains("shortcuts.") && !entry.key.contains(".tags")) {
-                    if (entry.value.get("AppName").get_string() == name) {
+                    if (entry.value.get("appname").get_string() == name) {
                         return int.parse(entry.key.split(".")[1]);
                     }
                 }
@@ -182,7 +182,7 @@ namespace ProtonPlus.Models.VDF {
             node.set("appid", new GLib.Variant.int32(shortcut.AppID));
             node.set("AllowDesktopConfig", new GLib.Variant.int32(shortcut.AllowDesktopConfig ? 1 : 0));
             node.set("AllowOverlay", new GLib.Variant.int32(shortcut.AllowOverlay ? 1 : 0));
-            node.set("AppName", new GLib.Variant.string(shortcut.AppName));
+            node.set("appname", new GLib.Variant.string(shortcut.AppName));
             node.set("Devkit", new GLib.Variant.int32(shortcut.Devkit));
             node.set("DevkitGameID", new GLib.Variant.string(shortcut.DevkitGameID));
             node.set("DevkitOverrideAppID", new GLib.Variant.int32(shortcut.DevkitOverrideAppID));


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Since the appname in Steam shortcuts is stored in lowercase, ProtonPlus fails to properly detect shortcuts modified by Steam. Ensuring consistent use of lowercase during both creation and reading resolves the issue.

### Issue Number
> Related issue: #396 #487

