### PR TITLE
Fix incorrect insertion position when launch options are missing

### DIFF
--- a/src/models/games/steam.vala
+++ b/src/models/games/steam.vala
@@ -155,15 +155,15 @@ namespace ProtonPlus.Models.Games {
 				if (app.contains("LaunchOptions")) {
 					start_text = "\n\t\t\t\t\t\t\"LaunchOptions\"\t\t\"";
 					start_pos = app.index_of(start_text, 0);
-
 					if (start_pos == -1)
 						return false;
 
 					end_text = "\"\n";
-					end_pos = app.index_of(end_text, start_pos + start_text.length) + end_text.length;
-
+					end_pos = app.index_of(end_text, start_pos + start_text.length);
 					if (end_pos == -1)
 						return false;
+
+					end_pos = end_pos + end_text.length - 1;
 
 					app_launch_options = app.substring(start_pos, end_pos - start_pos);
 					// message("start: %i, end: %i, app_launch_options: %s", start_pos, end_pos, app_launch_options);

--- a/src/models/games/steam.vala
+++ b/src/models/games/steam.vala
@@ -198,7 +198,14 @@ namespace ProtonPlus.Models.Games {
 				} else {
 					app_launch_options = "\n\t\t\t\t\t\t\"LaunchOptions\"\t\t\"%s\"".printf(escaped_launch_options);
 
-					app_modified = app.concat(app_launch_options);
+					end_pos = app.last_index_of("\n\t\t\t\t\t}");
+					if (end_pos == -1)
+						return false;
+
+					app_modified =
+						app.substring(0, end_pos) +
+						app_launch_options + 
+						app.substring(end_pos);
 				}
 			}
 


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> This issue only occurs when the LaunchOptions field doesn't exist; it's essentially just a position calculation problem.

### Issue Number
> Related issue: #503

