### PR TITLE
Improve scroll stability after clicking Load more

### DIFF
--- a/src/widgets/runners/runner-row.vala
+++ b/src/widgets/runners/runner-row.vala
@@ -77,10 +77,13 @@ namespace ProtonPlus.Widgets {
 			ScrollController scroll_ctrl = new ScrollController(get_ancestor(typeof(Gtk.ScrolledWindow)) as Gtk.ScrolledWindow);
 			scroll_ctrl.save();
 
-			remove (load_more_row);
-			expanded_changed (true);
+			GLib.Idle.add (() => {
+				remove (load_more_row);
+				expanded_changed (true);
 
-			scroll_ctrl.restore(10);
+				scroll_ctrl.restore(10);
+				return false;
+			});
 		}
 	}
 }


### PR DESCRIPTION
### Overview
> Perform row removal and addition during GLib.Idle to improve stability.

### Issue Number
> Related issue: #491