### PR TITLE
Fix the "apps" block end calculation in VDF parser

### DIFF
--- a/src/models/launchers/steam.vala
+++ b/src/models/launchers/steam.vala
@@ -107,7 +107,7 @@ namespace ProtonPlus.Models.Launchers {
                     start_text = "apps\"\n\t\t{\n";
                     end_text = "}";
                     start_pos = current_libraryfolder_content.index_of(start_text, current_position) + start_text.length;
-                    end_pos = current_libraryfolder_content.index_of(end_text, start_pos + start_text.length);
+                    end_pos = current_libraryfolder_content.index_of(end_text, start_pos);
                     current_apps = current_libraryfolder_content.substring(start_pos, end_pos - start_pos);
                     current_position = 0;
                     // message("start: %i, end: %i, apps: %s", start_pos, end_pos, current_apps);


### PR DESCRIPTION
### Category
>  Bugfix

### Overview
> When calculating the } of the `apps` block, `start_text.length` was mistakenly added. When the `apps` block is empty, this causes current_apps to be null, which in turn leads to an infinite loop in the following while.

### Issue Number
> Related issue: #451 

