### PR TITLE
Fix key case mismatch issue

### DIFF
--- a/src/models/vdf/node.vala
+++ b/src/models/vdf/node.vala
@@ -2,7 +2,12 @@ namespace ProtonPlus.Models.VDF {
     public class Node : Gee.TreeMap<string, GLib.Variant> {
         public string node_name;
 
+        static int case_insensitive_compare (string str1, string str2) {
+            return str1.casefold().collate(str2.casefold());
+        }
+
         public Node (string name) {
+            base((CompareDataFunc<string>) case_insensitive_compare);
             node_name = name;
         }
     }


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Added a custom key comparator to make key lookups case-insensitive.
> 
> For example, with Steam shortcuts, even if the stored key is `AppName`, calling `entry.value.get("appname") `will still correctly retrieve the corresponding value - and vice versa.
> 
> There's no need to store duplicate entries, nor to check both `AppName` and `appname` separately to see if the value exists.

