### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,26 +6,6 @@ on:
     - main
 
 jobs:
-  native-build:
-    name: "Native Build"
-    runs-on: ubuntu-latest
-    steps: 
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install gettext valac meson libadwaita-1-dev libarchive-dev libgee-0.8-dev libgtk-4-dev libjson-glib-dev libsoup-3.0-dev desktop-file-utils appstream-util
-    - name: Checkout pull request
-      uses: actions/checkout@v4.2.2
-      with:
-          ref: ${{ github.event.pull_request.head.sha }}
-    - name: Build
-      run: |
-        mkdir build
-        meson --prefix=/usr build
-        meson compile -C build
-    - name: Check
-      run: 'meson test -C build --print-errorlogs || :'
-
   flatpak-build:
     name: "Flatpak Build"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since ubuntu-latest doesn't have the required dependencies to build the application natively it is basically useless to check if it can build it.
