### PR TITLE
More robust yad version check fixes #934

### DIFF
--- a/src/widgets/runners/steamtinkerlaunch-row.vala
+++ b/src/widgets/runners/steamtinkerlaunch-row.vala
@@ -71,7 +71,12 @@ namespace ProtonPlus.Widgets {
             if (yield Utils.System.check_dependency ("yad")) {
                 string yad_version_output = yield Utils.System.run_command ("yad --version");
 
-                float version = float.parse (yad_version_output.split (" ")[0]);
+                float version = 0.0f;
+                var regex = new Regex ("""(\d+\.\d+)\s*\(GTK\+""");
+                MatchInfo match_info;
+                if (regex.match (yad_version_output, 0, out match_info)) {
+                    version = float.parse (match_info.fetch (1));
+                }
                 yad_installed = version >= 7.2;
             }
             if (!yad_installed)missing_dependencies += "yad >= 7.2\n";


### PR DESCRIPTION
### Category
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Translation
- [ ] Other (Please specify!)

### Overview
The method of extracting the version number from yad within the `steamtinkerlaunch` installer made the assumption that it's output would be exactly `<version>` then a space, however, if the user has some warnings from GTK this may not always be the case. For example if the user as an issue in their `gtk.css` they may have something like:
```sh
$ yad --version

(yad:753653): Gtk-WARNING **: 00:55:39.504: Theme parsing error: gtk.css:2:1: Invalid name of pseudo-class
14.2 (GTK+ 3.24.52)
```
My solution is to just use a regex to check for a `digit.digit` preceding any white space+`(GTK+`: `(\d+\.\d+)\s*\(GTK\+` which can successfully extract the version from `yad --version` while ignoring any warnings or other erroneous output.

### Issue Number
Fixes #934

### How to Test
Attempt to use ProtonPlus to install `steamtinkerlaunch` while you have some kind of GTK error which shows up in the `yad --version` output, prior to this patch it will fail and tell you that you don't have a compatible yad version installed. After this patch it successfully extracts the version from the output and recognises it.

### Screenshot (if applicable)
Before:
<img width="945" height="595" alt="5JlPJX2fN" src="https://github.com/user-attachments/assets/ff3a3b9d-f1e7-409b-a684-78e44d1bd667" />
After:
<img width="915" height="284" alt="Gz7Zq5UMp" src="https://github.com/user-attachments/assets/9793ddfc-02fd-428f-a442-81a486eadca0" />

### Checklist
- [x] My code follows the [Styleguide](https://github.com/Vysp3r/ProtonPlus/blob/main/CONTRIBUTING.md#styleguides) of this project.
- [x] I have tested my changes and verified that they work as expected.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have updated the translations by running `./scripts/build.sh translations` (if applicable).
- [x] I have checked for existing Pull Requests that cover these changes.

