### PR TITLE
Fix GE-Proton asset position

### DIFF
--- a/src/models/runners/github.vala
+++ b/src/models/runners/github.vala
@@ -91,6 +91,17 @@ namespace ProtonPlus.Models.Runners {
                     }
                 }
 
+                // Workaround for Proton-GE's multi-architecture support
+                while (asset_array.get_length () - 1 >= real_asset_position) {
+                    var asset_object = asset_array.get_object_element (real_asset_position);
+                    var asset_name = asset_object.get_string_member ("name");
+                    if (asset_name.contains (".tar") && !asset_name.contains ("aarch64")) {
+                        break;
+                    }
+
+                    real_asset_position++;
+                }
+
                 if (asset_position_hwcaps_condition) {
                     for (int y = 0; y < asset_array.get_length (); y++) {
                         var asset_object = asset_array.get_object_element (y);


### PR DESCRIPTION

### Category
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Translation
- [ ] Other (Please specify!)

### Overview
GE-Proton added aarch64 builds which were uploaded before the regular x86_64 builds in the release assets.

Currently it is not possible to download the aarch64 builds at all and the `asset_position_hwcaps_condition` runner option only supports `.tar.xz` as opposed to `tar.gz` which GE-Proton uses.

### Issue Number
#1064
#1065 

### How to Test
Downloaded GE-Proton 11 and 10 and verified both include x86(_64) binaries.

### Screenshot (if applicable)

![](https://media1.tenor.com/m/nA3E0n8pQXUAAAAd/warden-warden-deadlock.gif)

### Checklist
- [X] My code follows the [Styleguide](https://github.com/Vysp3r/ProtonPlus/blob/main/CONTRIBUTING.md#styleguides) of this project.
- [X] I have tested my changes and verified that they work as expected.
- [X] I have checked for existing Pull Requests that cover these changes.

