### PR TITLE
Add TinkerGame runner support

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -21,6 +21,7 @@ src/widgets/runners/installed-row.vala
 src/widgets/runners/basic-row.vala
 src/widgets/runners/filters-box.vala
 src/widgets/runners/steamtinkerlaunch-row.vala
+src/widgets/runners/tinkergame-row.vala
 src/widgets/games/games-box.vala
 src/widgets/games/game-row.vala
 src/widgets/games/mass-edit-view.vala
@@ -63,10 +64,12 @@ src/models/runners/github-action.vala
 src/models/runners/gitlab.vala
 src/models/runners/installed.vala
 src/models/runners/steamtinkerlaunch.vala
+src/models/runners/tinkergame.vala
 src/models/releases/basic.vala
 src/models/releases/github-action.vala
 src/models/releases/update.vala
 src/models/releases/steamtinkerlaunch.vala
+src/models/releases/tinkergame.vala
 src/models/releases/latest.vala
 src/utils/filesystem.vala
 src/utils/parser.vala

--- a/src/models/launcher.vala
+++ b/src/models/launcher.vala
@@ -232,6 +232,10 @@ namespace ProtonPlus.Models {
                         var stl_runner = new Runners.SteamTinkerLaunch (groups[i]);
 
                         groups[i].runners.append (stl_runner);
+
+                        var tg_runner = new Runners.TinkerGame (groups[i]);
+
+                        groups[i].runners.append (tg_runner);
                     }
                 }
 

--- a/src/models/releases/tinkergame.vala
+++ b/src/models/releases/tinkergame.vala
@@ -1,0 +1,372 @@
+namespace ProtonPlus.Models.Releases {
+    public class TinkerGame : Update<TG_Remove_Parameters> {
+        string home_location { get; set; }
+        string compat_location { get; set; }
+        string parent_location { get; set; }
+        public string base_location { get; set; }
+        string binary_location { get; set; }
+        string download_location { get; set; }
+        string meta_location { get; set; }
+        string link_parent_location { get; set; }
+        string link_location { get; set; }
+        string config_location { get; set; }
+        string manual_remove_location { get; set; }
+        List<string> external_locations;
+
+        string? latest_date { get; set; }
+        string? latest_hash { get; set; }
+        string local_date { get; set; }
+        string local_hash { get; set; }
+
+        public TinkerGame (Runner runner) {
+            Object (runner: runner,
+                    title: "TinkerGame");
+
+            home_location = Environment.get_home_dir ();
+            compat_location = runner.group.launcher.directory + runner.group.directory;
+            if (Globals.IS_STEAM_OS) {
+            // Steam Deck uses `~/tg/prefix` instead.
+                parent_location = @"$home_location/tg";
+                base_location = @"$parent_location/prefix";
+                manual_remove_location = parent_location;
+            } else {
+            // Normal computers use `~/.local/share/tinkergame`.
+                parent_location = @"$home_location/.local/share";
+                base_location = @"$parent_location/tinkergame";
+                manual_remove_location = base_location;
+            }
+            binary_location = @"$base_location/tinkergame";
+            meta_location = @"$base_location/ProtonPlus.meta";
+            download_location = @"$base_location/ProtonPlus.downloads";
+            link_parent_location = @"$home_location/.local/bin";
+            link_location = @"$link_parent_location/tinkergame";
+            config_location = @"$home_location/.config/tinkergame";
+            external_locations = new List<string> ();
+
+            refresh_latest_tinkergame_version.begin ((obj, res) => {
+                refresh_state ();
+            });
+        }
+
+        string get_download_url () {
+            return @"https://github.com/360900/tinkergame/archive/$latest_hash.zip";
+        }
+
+        async void exec_tg (string exec_location, string args) {
+            if (!FileUtils.test (exec_location, FileTest.IS_REGULAR))
+            return;
+
+            if (!FileUtils.test (exec_location, FileTest.IS_EXECUTABLE))
+            yield Utils.System.run_command (@"chmod +x $exec_location");
+
+            yield Utils.System.run_command (@"$exec_location $args");
+        }
+
+        async void refresh_latest_tinkergame_version () {
+            latest_date = "";
+            latest_hash = "";
+
+            string? response;
+
+            var code = yield Utils.Web.get_request ("https://api.github.com/repos/360900/tinkergame/commits?per_page=1", Utils.Web.GetType.TINKERGAME, out response);
+
+            if (code != ReturnCode.VALID_REQUEST)
+            return;
+
+            var root_node = Utils.Parser.get_node_from_json (response);
+
+            if (root_node.get_node_type () != Json.NodeType.ARRAY)
+            return;
+
+            var root_array = root_node.get_array ();
+
+            if (root_array.get_length () < 1)
+            return;
+
+
+            // Get the first (newest) commit in the list.
+            var commit_node = root_array.get_element (0);
+
+            if (commit_node.get_node_type () != Json.NodeType.OBJECT)
+            return;
+
+            var commit_obj = commit_node.get_object ();
+
+
+            // Get metadata about the committer (not the author), since
+            // we want to know when it was committed to the repo.
+            if (!commit_obj.has_member ("commit"))
+            return;
+
+            var commit_metadata_node = commit_obj.get_member ("commit");
+
+            if (commit_metadata_node.get_node_type () != Json.NodeType.OBJECT)
+            return;
+
+            var commit_metadata_obj = commit_metadata_node.get_object ();
+
+
+            if (!commit_metadata_obj.has_member ("committer"))
+            return;
+
+            var committer_metadata_node = commit_metadata_obj.get_member ("committer");
+
+            if (committer_metadata_node.get_node_type () != Json.NodeType.OBJECT)
+            return;
+
+            var committer_metadata_obj = committer_metadata_node.get_object ();
+
+
+            // Extract the latest commit's date and SHA hash.
+            // NOTE: The date is in ISO 8601 format (UTC): `YYYY-MM-DDTHH:MM:SSZ`.
+            string raw_date = committer_metadata_obj.get_string_member_with_default ("date", "");
+            var date_parts = raw_date.split ("T");
+            if (date_parts.length > 0) {
+                latest_date = date_parts[0];     // "YYYY-MM-DD".
+            }
+
+            latest_hash = commit_obj.get_string_member_with_default ("sha", "");
+            download_url = get_download_url ();
+        }
+
+        void write_installation_metadata (string meta_location) {
+            Utils.Filesystem.create_file (meta_location, @"$latest_date:$latest_hash");
+        }
+
+        public bool detect_external_locations () {
+            if (external_locations.length () > 0)
+            external_locations = new List<string> ();
+
+            var location = @"$home_location/TinkerGame";
+            if (FileUtils.test (location, FileTest.IS_DIR))
+            external_locations.append (location);
+
+            location = Environment.get_home_dir () + "/tg";
+            if (!Globals.IS_STEAM_OS && FileUtils.test (location, FileTest.IS_DIR))
+            external_locations.append (location);
+
+            return external_locations.length () > 0;
+        }
+
+        protected override void refresh_state () {
+        // Update the ProtonPlus UI state variables.
+        // NOTE: We treat a non-executable binary as a "broken installation".
+            var base_location_exists = FileUtils.test (base_location, FileTest.IS_DIR);
+            var binary_location_exists = FileUtils.test (binary_location, FileTest.IS_EXECUTABLE);
+            var meta_file_exists = FileUtils.test (meta_location, FileTest.IS_REGULAR);
+
+            var installed = base_location_exists && binary_location_exists && meta_file_exists;
+            var updated = false;
+
+            local_date = "";
+            local_hash = "";
+
+            if (installed) {
+                var raw_metadata = Utils.Filesystem.get_file_content (meta_location);
+                var metadata_parts = raw_metadata.strip ().split (":");
+                if (metadata_parts.length >= 2) {
+                    local_date = metadata_parts[0];
+                    local_hash = metadata_parts[1];
+                // Ignore both values if either is missing.
+                    if (local_date == "" || local_hash == "")
+                    local_date = local_hash = "";
+                }
+
+                if (local_hash == "")
+                installed = false;
+                    else if (latest_hash != "")
+                    updated = latest_hash == local_hash;
+            }
+
+            step = Step.NOTHING;
+
+            // Generate a title for the installed (or latest) release.
+            var _row_title = title; // Default title/prefix.
+            if (local_date != "")
+            _row_title = @"$_row_title ($local_date)";
+                else if (latest_date != "")
+                _row_title = @"$_row_title ($latest_date)";
+
+
+                // Update state to trigger the signals for UI refresh.
+                // WARNING: We MUST do this LAST, after finishing ALL other vars
+                // above, otherwise the UI redraw would happen with old values.
+                displayed_title = _row_title;
+
+                state = !installed ? State.NOT_INSTALLED : updated ? State.UP_TO_DATE : State.UPDATE_AVAILABLE;
+        }
+
+        protected async override bool _start_install () {
+            if (yield Utils.System.check_dependency ("tinkergame"))
+            yield Utils.System.run_command ("tinkergame compat del");
+
+            yield exec_tg (@"$compat_location/TinkerGame/tinkergame", "compat del");
+
+            foreach (var location in external_locations) {
+                var deleted = yield Utils.Filesystem.delete_directory (location);
+
+                if (!deleted)
+                return false;
+            }
+
+            // Always clean destination to avoid merging with existing files.
+            // NOTE: We check for ANY existing (conflicting) file, not just
+            // dirs. The `remove` function then validates the actual types.
+            var base_location_exists = FileUtils.test (base_location, FileTest.EXISTS);
+            if (base_location_exists) {
+                var deleted_old_files = yield remove (new Models.Releases.TinkerGame.TG_Remove_Parameters ());
+
+                if (!deleted_old_files)
+                return false;
+            }
+
+
+            // Download the source code archive.
+            // NOTE: We only create "downloads", since it's a subdir of `base_location`.
+            if (!FileUtils.test (download_location, FileTest.IS_DIR)) {
+                var download_dir_exists = yield Utils.Filesystem.create_directory (download_location);
+
+                if (!download_dir_exists)
+                return false;
+            }
+
+            string downloaded_file_location = @"$download_location/$title.zip";
+
+            if (FileUtils.test (downloaded_file_location, FileTest.EXISTS)) {
+                var deleted = Utils.Filesystem.delete_file (downloaded_file_location);
+
+                if (!deleted)
+                return false;
+            }
+
+            step = Step.DOWNLOADING;
+
+            string? download_error;
+            var download_valid = yield Utils.Web.Download (get_download_url (), downloaded_file_location, () => canceled, (is_percent, progress, speed_kbps, seconds_remaining) => {
+                this.is_percent = is_percent;
+                this.progress = is_percent ? @"$progress%" : Utils.Filesystem.convert_bytes_to_string (progress);
+                this.speed_kbps = speed_kbps;
+                this.seconds_remaining = seconds_remaining;
+            }, out download_error);
+
+            if (!download_valid) {
+                this.error_message = download_error;
+                return false;
+            }
+
+            step = Step.EXTRACTING;
+
+            // Extract archive and move its contents to the installation directory.
+            string extracted_file_location = yield Utils.Filesystem.extract (@"$download_location/", title, ".zip", () => canceled);
+
+            if (extracted_file_location == "")
+            return false;
+
+            var moved = yield Utils.Filesystem.move_dir_contents (extracted_file_location, base_location);
+
+            if (!moved)
+            return false;
+
+
+            // We don't need the download directory anymore.
+            var download_deleted = yield Utils.Filesystem.delete_directory (download_location);
+
+            if (!download_deleted)
+            return false;
+
+
+            // Create a symlink for the tinkergame binary.
+            var link_parent_location_exists = yield Utils.Filesystem.create_directory (link_parent_location);
+
+            if (!link_parent_location_exists)
+            return false;
+
+            var link_created = yield Utils.Filesystem.make_symlink (link_location, binary_location);
+
+            if (!link_created)
+            return false;
+
+
+            // Trigger TinkerGame's dependency installer for Steam Deck, and register compat tool.
+            if (Globals.IS_STEAM_OS)
+            yield exec_tg (binary_location, "");
+
+            yield exec_tg (binary_location, "compat add");
+
+
+            // Remember installed version.
+            write_installation_metadata (meta_location);
+
+
+            // Add TinkerGame to Games tab
+            var simple_runner = new SimpleRunner.from_path("%s/TinkerGame".printf (compat_location));
+            runner.group.launcher.compatibility_tools.add (simple_runner);
+
+            return true;
+        }
+
+        protected override async bool _start_remove (TG_Remove_Parameters parameters) {
+            yield exec_tg (binary_location, "compat del");
+
+        // NOTE: We check specific types to avoid deleting unexpected data.
+            if (FileUtils.test (link_location, FileTest.EXISTS)) {
+                if (!FileUtils.test (link_location, FileTest.IS_SYMLINK))
+                return false;
+
+                var link_deleted = Utils.Filesystem.delete_file (link_location);
+
+                if (!link_deleted)
+                return false;
+            }
+
+            var remove_location = parameters.user_request ? manual_remove_location : base_location;
+            if (FileUtils.test (remove_location, FileTest.EXISTS)) {
+                if (!FileUtils.test (remove_location, FileTest.IS_DIR))
+                return false;
+
+                var base_deleted = yield Utils.Filesystem.delete_directory (remove_location);
+
+                if (!base_deleted)
+                return false;
+            }
+
+            if (parameters.delete_config && FileUtils.test (config_location, FileTest.EXISTS)) {
+                if (!FileUtils.test (config_location, FileTest.IS_DIR))
+                return false;
+
+                var config_deleted = yield Utils.Filesystem.delete_directory (config_location);
+
+                if (!config_deleted)
+                return false;
+            }
+
+            foreach (var simple_runner in runner.group.launcher.compatibility_tools) {
+                if (simple_runner.path == "%s/TinkerGame".printf (compat_location)) {
+                    runner.group.launcher.compatibility_tools.remove (simple_runner);
+                    break;
+                }
+            }
+
+            return true;
+        }
+
+        protected override async bool _start_update () {
+            var remove_success = yield remove (new Models.Releases.TinkerGame.TG_Remove_Parameters ());
+
+            if (!remove_success)
+            return false;
+
+            var install_success = yield install ();
+
+            if (!install_success)
+            return false;
+
+            return true;
+        }
+
+        public class TG_Remove_Parameters : Parameters {
+            public bool delete_config { get; set; default = false; }
+            public bool user_request { get; set; default = false; }
+        }
+    }
+}

--- a/src/models/runners/tinkergame.vala
+++ b/src/models/runners/tinkergame.vala
@@ -1,0 +1,19 @@
+namespace ProtonPlus.Models.Runners {
+    public class TinkerGame : Runner {
+        public TinkerGame (Models.Group group) {
+            Object (group: group,
+                    title: "TinkerGame",
+                    description: _ ("Steam tool for easy, graphical configuration of your other compatibility tools for both Windows games and native Linux games. A community fork of SteamTinkerLaunch."));
+        }
+
+        public override async ReturnCode load (out List<Models.Release> releases) {
+            releases = new List<Models.Release> ();
+
+            var release = new Releases.TinkerGame (this);
+
+            releases.append (release);
+
+            return ReturnCode.RELEASES_LOADED;
+        }
+    }
+}

--- a/src/utils/web.vala
+++ b/src/utils/web.vala
@@ -9,6 +9,7 @@ namespace ProtonPlus.Utils {
             GITLAB,
             FORGEJO,
             STEAMTINKERLAUNCH,
+            TINKERGAME,
         }
 
         static Soup.Session? _session = null;
@@ -28,7 +29,7 @@ namespace ProtonPlus.Utils {
                 var message = new Soup.Message ("GET", uri);
 
                 if (Globals.SETTINGS != null) {
-                    if (get_type == GetType.GITHUB || get_type == GetType.STEAMTINKERLAUNCH) {
+                    if (get_type == GetType.GITHUB || get_type == GetType.STEAMTINKERLAUNCH || get_type == GetType.TINKERGAME) {
                         var key = Globals.SETTINGS.get_string ("github-api-key");
                         if (key.length > 0)
                         message.request_headers.append ("Authorization", "token %s".printf (key));
@@ -40,7 +41,7 @@ namespace ProtonPlus.Utils {
                         message.request_headers.append ("Authorization", "Bearer %s".printf (key));
                     }
 
-                    if (get_type == GetType.STEAMTINKERLAUNCH) {
+                    if (get_type == GetType.STEAMTINKERLAUNCH || get_type == GetType.TINKERGAME) {
                         message.request_headers.append ("Accept", "application/vnd.github+json");
                         message.request_headers.append ("X-GitHub-Api-Version", "2022-11-28");
                     }

--- a/src/widgets/runners/runner-row.vala
+++ b/src/widgets/runners/runner-row.vala
@@ -106,6 +106,10 @@ namespace ProtonPlus.Widgets {
                     var row = new Widgets.SteamTinkerLaunchRow ((Models.Releases.SteamTinkerLaunch) release);
                     add_row (row);
                     rows.append (row);
+                } else if (release is Models.Releases.TinkerGame) {
+                    var row = new Widgets.TinkerGameRow ((Models.Releases.TinkerGame) release);
+                    add_row (row);
+                    rows.append (row);
                 } else {
                     continue;
                 }

--- a/src/widgets/runners/tinkergame-row.vala
+++ b/src/widgets/runners/tinkergame-row.vala
@@ -1,0 +1,215 @@
+namespace ProtonPlus.Widgets {
+    public class TinkerGameRow : ReleaseRow {
+        Models.Releases.TinkerGame release;
+
+        public TinkerGameRow (Models.Releases.TinkerGame release) {
+            this.release = release;
+
+            update_button.set_tooltip_text (_ ("Update to the latest version"));
+
+            if (release.runner.group.launcher.installation_type != Models.Launcher.InstallationTypes.SYSTEM) {
+                input_box.remove (install_button);
+                input_box.remove (remove_button);
+                input_box.remove (update_button);
+            } else {
+                input_box.remove (info_button);
+            }
+
+            release.notify["displayed-title"].connect (release_displayed_title_changed);
+
+            release_displayed_title_changed ();
+
+            release.notify["state"].connect (release_state_changed);
+
+            release_state_changed ();
+
+            Models.DownloadManager.instance.download_added.connect (on_download_status_changed);
+            Models.DownloadManager.instance.download_removed.connect (on_download_status_changed);
+        }
+
+        private void on_download_status_changed (Models.BaseRelease added_release) {
+            if (added_release.download_url == release.download_url && added_release.title == release.title) {
+                release_state_changed ();
+            }
+        }
+
+        protected override void update_button_clicked () {
+            release.update.begin ((obj, res) => {
+                var success = release.update.end (res);
+                if (!success && !release.canceled) {
+                    var dialog = new ErrorDialog (_ ("Couldn't update %s").printf (release.title), _ ("Please report this issue on GitHub."));
+                    dialog.present (Application.window);
+                }
+            });
+            Application.window.show_downloads_page ();
+        }
+
+        protected override void install_button_clicked () {
+        // Steam Deck doesn't need any external dependencies.
+            if (!Globals.IS_STEAM_OS) {
+                dependency_check.begin ((obj, res) => {
+                    var missing_dependencies = dependency_check.end (res);
+
+                    if (missing_dependencies != "") {
+                        var alert_dialog = new WarningDialog (_ ("Warning"), "%s\n\n%s\n%s".printf (_ ("You are missing the following dependencies for %s:").printf (title), missing_dependencies, _ ("Installation will be canceled.")));
+                        alert_dialog.present (Widgets.Application.window);
+
+                        return;
+                    } else {
+                        external_install_check ();
+                    }
+                });
+            } else {
+                external_install_check ();
+            }
+        }
+
+        async string dependency_check () {
+            var missing_dependencies = "";
+
+            var yad_installed = false;
+            if (yield Utils.System.check_dependency ("yad")) {
+                string yad_version_output = yield Utils.System.run_command ("yad --version");
+
+                float version = 0.0f;
+                var regex = new Regex ("""(\d+\.\d+)\s*\(GTK\+""");
+                MatchInfo match_info;
+                if (regex.match (yad_version_output, 0, out match_info)) {
+                    version = float.parse (match_info.fetch (1));
+                }
+                yad_installed = version >= 7.2;
+            }
+            if (!yad_installed)missing_dependencies += "yad >= 7.2\n";
+
+            if (!(yield Utils.System.check_dependency ("awk")) && !(yield Utils.System.check_dependency ("gawk")))missing_dependencies += "awk/gawk\n";
+            if (!(yield Utils.System.check_dependency ("git")))missing_dependencies += "git\n";
+            if (!(yield Utils.System.check_dependency ("pgrep")))missing_dependencies += "pgrep\n";
+            if (!(yield Utils.System.check_dependency ("unzip")))missing_dependencies += "unzip\n";
+            if (!(yield Utils.System.check_dependency ("wget")))missing_dependencies += "wget\n";
+            if (!(yield Utils.System.check_dependency ("xdotool")))missing_dependencies += "xdotool\n";
+            if (!(yield Utils.System.check_dependency ("xprop")))missing_dependencies += "xprop\n";
+            if (!(yield Utils.System.check_dependency ("xrandr")))missing_dependencies += "xrandr\n";
+            if (!(yield Utils.System.check_dependency ("xxd")))missing_dependencies += "xxd\n";
+            if (!(yield Utils.System.check_dependency ("xwininfo")))missing_dependencies += "xwininfo\n";
+
+            return missing_dependencies;
+        }
+
+        void external_install_check () {
+            var has_external_install = release.detect_external_locations ();
+
+            if (has_external_install) {
+                var alert_dialog = new Adw.AlertDialog (_ ("Warning"), "%s\n\n%s".printf (_ ("It looks like you currently have another version of %s which was not installed by ProtonPlus.").printf (title.split (" ")[0]), _ ("Do you want to reinstall it with ProtonPlus?")));
+
+                alert_dialog.add_response ("no", _ ("No"));
+                alert_dialog.add_response ("yes", _ ("Yes"));
+
+                alert_dialog.set_response_appearance ("no", Adw.ResponseAppearance.DEFAULT);
+                alert_dialog.set_response_appearance ("yes", Adw.ResponseAppearance.DESTRUCTIVE);
+
+                alert_dialog.choose.begin (Widgets.Application.window, null, (obj, res) => {
+                    string response = alert_dialog.choose.end (res);
+
+                    if (response == "yes")
+                    start_install ();
+                });
+            } else {
+                start_install ();
+            }
+        }
+
+        void start_install () {
+            release.install.begin ((obj, res) => {
+                var success = release.install.end (res);
+                if (!success && !release.canceled) {
+                    var dialog = new ErrorDialog (_ ("Couldn't install %s").printf (release.title), _ ("Please report this issue on GitHub."));
+                    dialog.present (Application.window);
+                }
+            });
+            Application.window.show_downloads_page ();
+        }
+
+        protected override void remove_button_clicked () {
+            var parameters = new Models.Releases.TinkerGame.TG_Remove_Parameters ();
+            parameters.delete_config = false;
+            parameters.user_request = true;
+
+            var remove_config_check = new Gtk.CheckButton.with_label (_ ("Check this to also delete your configuration files."));
+            remove_config_check.activate.connect (() => {
+                parameters.delete_config = remove_config_check.get_active ();
+            });
+
+            var remove_dialog = new RemoveDialog (release, parameters);
+            remove_dialog.set_extra_child (remove_config_check);
+            remove_dialog.present (Application.window);
+        }
+
+        protected override void info_button_clicked () {
+            Adw.AlertDialog? alert_dialog = null;
+            switch (release.runner.group.launcher.installation_type) {
+                case Models.Launcher.InstallationTypes.FLATPAK :
+                    // NOTE: There is no TinkerGame Flatpak on Flathub yet, only the
+                    // upstream SteamTinkerLaunch Flatpak
+                    // (com.valvesoftware.Steam.Utility.steamtinkerlaunch).
+                    alert_dialog = new WarningDialog (_ ("Warning"), _ ("There's currently no TinkerGame Flatpak available for the %s. Only the upstream SteamTinkerLaunch Flatpak exists.").printf ("Steam Flatpak"));
+                    break;
+                case Models.Launcher.InstallationTypes.SNAP:
+                    alert_dialog = new WarningDialog (_ ("Warning"), _ ("There's currently no known way for us to install %s for the %s.").printf (release.title, "Steam Snap"));
+                    break;
+                default:
+                    break;
+            }
+
+            if (alert_dialog != null)
+            alert_dialog.present (Application.window);
+        }
+
+        protected override void open_button_clicked () {
+            Utils.System.open_uri ("file://%s".printf (release.base_location));
+        }
+
+        void release_displayed_title_changed () {
+            set_title (release.displayed_title);
+
+            only_show ();
+        }
+
+        void release_state_changed () {
+            var installed = release.state == Models.BaseRelease.State.UP_TO_DATE || release.state == Models.BaseRelease.State.UPDATE_AVAILABLE;
+            var updated = release.state == Models.BaseRelease.State.UP_TO_DATE;
+            var busy = release.state == Models.BaseRelease.State.BUSY_INSTALLING ||
+            release.state == Models.BaseRelease.State.BUSY_REMOVING ||
+            release.state == Models.BaseRelease.State.BUSY_UPDATING;
+
+            install_button.set_visible (!installed);
+            remove_button.set_visible (installed);
+            update_button.set_visible (installed && !updated);
+            open_button.set_visible (installed);
+
+            install_button.set_sensitive (!busy);
+            remove_button.set_sensitive (!busy);
+            update_button.set_sensitive (!busy);
+            open_button.set_sensitive (!busy);
+
+            if (busy) {
+                var tooltip_text = _ ("This tool is currently being installed");
+                if (Models.DownloadManager.instance.is_downloading (release))
+                tooltip_text = _ ("This tool is currently being downloaded");
+                if (release.state == Models.BaseRelease.State.BUSY_REMOVING)
+                tooltip_text = _ ("This tool is currently being removed");
+                if (release.state == Models.BaseRelease.State.BUSY_UPDATING)
+                tooltip_text = _ ("This tool is currently being updated");
+
+                install_button.set_tooltip_text (tooltip_text);
+                remove_button.set_tooltip_text (tooltip_text);
+                update_button.set_tooltip_text (tooltip_text);
+                open_button.set_tooltip_text (tooltip_text);
+            } else {
+                install_button.set_tooltip_text (_ ("Install %s").printf (release.title));
+                remove_button.set_tooltip_text (_ ("Delete %s").printf (release.title));
+                update_button.set_tooltip_text (_ ("Update to the latest version"));
+                open_button.set_tooltip_text (_ ("Open runner directory"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds TinkerGame as a supported runner in ProtonPlus, with release detection, a runner row, and wiring into the launcher and web fetching.

## Changes

- `src/models/runners/tinkergame.vala`: runner definition.
- `src/models/releases/tinkergame.vala`: GitHub release detection.
- `src/widgets/runners/tinkergame-row.vala`: runner row widget.
- `src/models/launcher.vala`, `src/widgets/runners/runner-row.vala`, `src/utils/web.vala`: wire the new runner in.
- `po/POTFILES`: new translatable files.

## Context

TinkerGame is a fork of SteamTinkerLaunch (see 360900/tinkergame) whose script is `tinkergame`. Note: I could not run `valac` locally, so the Vala changes are reviewed structurally only and should be verified in a real meson build.