### PR TITLE
add back `com.vysp3r.ProtonPlus `

### DIFF
--- a/scripts/make-appimage.sh
+++ b/scripts/make-appimage.sh
@@ -29,6 +29,7 @@ export DEPLOY_P11KIT=1
 # Deploy dependencies
 quick-sharun \
     /usr/bin/protonplus \
+    /usr/share/com.vysp3r.ProtonPlus \
     /usr/lib/gio/modules/libgiognomeproxy.so \
     /usr/lib/gio/modules/libgiognutls.so \
     /usr/lib/gio/modules/libgiolibproxy.so


### PR DESCRIPTION
https://github.com/Vysp3r/ProtonPlus/pull/1171#issuecomment-5219256433

checking the commits in 6.0.0 branch: https://github.com/Vysp3r/ProtonPlus/commits/v0.6.0/

I do not see a commit that explicitly removed the `/usr/share/com.vysp3r.ProtonPlus`, instead what shows up is that my rebase [removed the directory](https://github.com/Vysp3r/ProtonPlus/commit/c481468f8df3f01dd17bd1e79cf4e38b508bac8b)

I don't understand how the previous PR diff never showed this.