### PR TITLE
Centralize Steam compatibility-tool discovery and validation

### DIFF
--- a/com.vysp3r.ProtonPlus.local.yml
+++ b/com.vysp3r.ProtonPlus.local.yml
@@ -23,6 +23,9 @@ finish-args:
   - --filesystem=xdg-run/gvfsd
   # Required because Steam libraries can be installed anywhere on the host.
   - --filesystem=host
+  # Read-only Flatpak deployment metadata used to discover Steam extensions.
+  - --filesystem=xdg-data/flatpak:ro
+  - --filesystem=/var/lib/flatpak:ro
   # Request access to supported Flatpak apps
   - --filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic
   # Read-only markers used to detect the Faugus Flatpak installation.

--- a/com.vysp3r.ProtonPlus.yml
+++ b/com.vysp3r.ProtonPlus.yml
@@ -23,6 +23,9 @@ finish-args:
   - --filesystem=xdg-run/gvfsd
   # Required because Steam libraries can be installed anywhere on the host.
   - --filesystem=host
+  # Read-only Flatpak deployment metadata used to discover Steam extensions.
+  - --filesystem=xdg-data/flatpak:ro
+  - --filesystem=/var/lib/flatpak:ro
   # Request access to supported Flatpak apps
   - --filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic
   # Read-only markers used to detect the Faugus Flatpak installation.

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -112,7 +112,7 @@ provider, source, and specialized-workflow extension rules.
 ### Installed-state discovery
 
 Every `Group` owns one `InstalledToolInventory`. It scans the launcher's
-physical tool directories, reads `.protonplus` metadata and compatibility-tool
+ProtonPlus-managed tool directories, reads `.protonplus` metadata and compatibility-tool
 manifests, and resolves installed entries back to tools. Stable persisted
 identity wins; carefully bounded legacy fallbacks may migrate metadata when a
 match is unambiguous.
@@ -121,6 +121,19 @@ Services invalidate this inventory after installation or removal. Consumers
 refresh it at an explicit boundary and read a snapshot. Do not let a widget or
 each tool independently rescan the same directory; that creates stale and
 cross-launcher state.
+
+Steam-selectable tools have a separate boundary:
+`SteamCompatibilityToolDiscovery` reads Steam library apps, the active Steam
+`compatibilitytools.d`, native distro roots, or Flatpak Steam extensions as
+appropriate for that launcher. External entries remain lightweight
+`CompatibilityTool` models and never enter inventory or installation
+workflows. `CompatibilityTool.path` is the launcher/host path; its explicit
+inspection path is used for sandbox-side VDF, Proton-launcher, and bounded
+feature probes. Package/custom roots obtain their exact identity from
+`compatibilitytool.vdf`. Official Steam library tools instead use their stable
+Valve app ID mapping and require a regular `toolmanifest.vdf`; Proton entries
+also require a regular `proton` launcher. Display names never supply persisted
+Steam compatibility-tool IDs.
 
 ### Install, update, and removal
 

--- a/docs/launch-options.md
+++ b/docs/launch-options.md
@@ -19,6 +19,10 @@ resolved internal title must match a discovered compatibility tool with a
 concrete installation path. If the mapping is absent, stale, or points to a
 missing installation, keep only generic Proton capabilities; never infer the
 default from list order, a provider name, or the newest-looking version.
+When ProtonPlus runs in Flatpak while controlling native Steam, the tool's
+launcher path remains the host `/usr/...` path, while bounded documentation and
+launcher probes use its `/run/host/usr/...` inspection path. Never persist or
+pass the inspection alias to a host-side command.
 
 Each rule declares a capability and one or more exact source/documentation
 markers. The resolver checks a bounded set of files in each installed tool and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,6 +66,7 @@ meson test -C build --print-errorlogs "ProtonPlus unit tests"
 | Launcher/tool identity and layout | `/identity`, `/install-layout`, launcher-specific tests, `variant_settings_test.vala`. |
 | CPU/variant selection | `/cpu-capabilities`, `/variant-compatibility`, `/variant-selector`. |
 | Installed state and metadata | `/installed-tool-inventory`, `/metadata`, `/compatibility-tool`. |
+| Steam selectable-tool discovery | `/steam-compatibility-tool-discovery`; injected Steam-library, native-system, and Flatpak extension roots only. `/steam/library-compatibility-tools-use-stable-identities` covers the library-loading projection. |
 | Installation and updates | `/compatibility-process-guard`, `/installer-transaction`, `/update-transaction`, `/steamtinkerlaunch`. |
 | VDF and Steam library parsing | `/vdf`, `/vdf-binary`, `/vdf-shortcuts`, `/steam`. |
 | Steam lifecycle | `/steam-session`, `/steam-configuration`, `/steam-restart-manager`, `/steam-restart-orchestrator`, `/steam-restart-presentation`. |

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -33,6 +33,7 @@ src/models/release-catalog-result.vala
 src/models/release-catalog.vala
 src/models/release.vala
 src/models/steam-change-receipt.vala
+src/models/steam-compatibility-tool-discovery.vala
 src/models/steam-profile.vala
 src/models/steam-restart-operation.vala
 src/models/steam-restart-target.vala

--- a/po/ar.po
+++ b/po/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-02-03 11:54+0000\n"
 "Last-Translator: Mujtaba-Alsaleh <mujtaba.m.alsaleh@gmail.com>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/protonplus/"
@@ -1995,7 +1995,7 @@ msgstr "%ds"
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "النظام"
@@ -2103,6 +2103,11 @@ msgstr "الصينية"
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
 msgstr "الصينية (التقليدية)"
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
@@ -2215,12 +2220,12 @@ msgstr "فشل النقل"
 msgid "Failed to save compatibility tool metadata"
 msgstr "فشل حفظ بيانات أداة التوافق"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "فشل تحديث compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "الكشف الخاص بأداة التوافق غير صالح أو غير مكتمل"
@@ -2399,7 +2404,7 @@ msgstr "أعلى"
 msgid "Top face button"
 msgstr "زر الوجه الأعلى"
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr "لم يتم العثور على أي لعبة"
@@ -2477,38 +2482,38 @@ msgstr "إن أردت مني إسراع عملية التطوير الرجاء �
 msgid "Default"
 msgstr "إفتراضي"
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr "تصفية: أصلي"
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr "تصفية: Non-Steam"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "تصفية: جميع الألعاب"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "لا توجد ألعاب مطابقة"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr "جرب لفظ بحث آخر أو أفرغ خانة البحث"
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr "لا توجد ألعاب مطابقة للتصفية الحالية"
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr "إختر جميع الألعاب لرؤية المكتبة بأكملها."
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr "لا توجد ألعاب متوفرة لمشغل البرامج هذا."
 
@@ -2614,6 +2619,7 @@ msgstr ""
 "تغيير."
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr "لا يمكن تطبيق أداة التوافق"
 
@@ -2621,26 +2627,33 @@ msgstr "لا يمكن تطبيق أداة التوافق"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr "لم يتم تغيير أي لعبة بسبب عدم وجود أداة توافق محددة."
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "لم يتم تغيير أي لعبة بسبب عدم وجود أداة توافق محددة."
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr "خيارات التشغيل المحددة غير مكتملة أو غير مدعومة لهذه الألعاب."
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr "لا يمكن ضبط خيارات التشغيل"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr "لم يتم تغيير أي لعبة بسبب عدم القدرة على تجهيز أمر التشغيل بشكل آمن."
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr "فشلت مجموعة التحديث"
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3621,7 +3634,7 @@ msgstr "إفتراضيات النظام"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Gamescope"
@@ -3633,7 +3646,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5149,12 +5162,12 @@ msgstr "يُبقِي محتوى الـShell الغير متعرف عليه, ال
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "متقدم"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr "تجريبي"
 
@@ -5539,7 +5552,7 @@ msgid "Tools"
 msgstr "الأدوات"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr "MangoHud"
 
@@ -6052,7 +6065,7 @@ msgid "Media Info"
 msgstr "معلومات الوسائط"
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr "الشبكة"
 
@@ -6586,129 +6599,129 @@ msgstr "أعرض الأدوات القديمة التي لم تعد تحت ال�
 msgid "Launchers"
 msgstr "البرامج المٌشغلة"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr "أداة التوافق الإفتراضية"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr "أداة التوافق التي سيتم إستخدامها من قبل الألعاب بشكل إفتراضي"
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "الملف الشخصي المحدد"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr "ملف التعريف المستخدم حالياً من قبل Steam"
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr "API Tokens"
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr "Proxy URL"
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr "مثال: http://127.0.0.1:7890 أو socks5://127.0.0.1:1080"
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr "معاينة المميزات"
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr "تفعيل المميزات التجريبية للإختبار المبكر"
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "الصيانة"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr "بيئة البرمجيات"
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "نعم"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "لا"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr "Flatpak"
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr "عتاد"
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr "HWCAPS"
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr "التبعيات"
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr "Protontricks (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr "MangoHud (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Feral Gamemode"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "البرامج المٌشغلة المكتشفة"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "مُثبَت"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "غير مُثبَت"
@@ -6920,11 +6933,11 @@ msgstr[3] "الألعاب المحددة %d"
 msgstr[4] "الألعاب المحددة %d"
 msgstr[5] "الألعاب المحددة %d"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr "فشل الترحيل"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2024-05-31 16:22+0000\n"
 "Last-Translator: Yahor <k1llo2810@protonmail.com>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/protonplus/"
@@ -1978,7 +1978,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2085,6 +2085,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2198,13 +2203,13 @@ msgid "Failed to save compatibility tool metadata"
 msgstr ""
 "Просты менеджэр інструментаў сумяшчальнасці на базе Wine і Proton для GNOME"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr ""
 "Просты менеджэр інструментаў сумяшчальнасці на базе Wine і Proton для GNOME"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr ""
@@ -2386,7 +2391,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr ""
@@ -2464,36 +2469,36 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2597,6 +2602,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr ""
@@ -2606,26 +2612,34 @@ msgstr ""
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr ""
+"Просты менеджэр інструментаў сумяшчальнасці на базе Wine і Proton для GNOME"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3513,7 +3527,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3524,7 +3538,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4927,12 +4941,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5296,7 +5310,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5781,7 +5795,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6321,127 +6335,127 @@ msgstr ""
 msgid "Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr ""
 "Просты менеджэр інструментаў сумяшчальнасці на базе Wine і Proton для GNOME"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 msgid "Protontricks"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Толькі ўсталяваныя"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Толькі ўсталяваныя"
@@ -6655,12 +6669,12 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Усталяванне "
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/bs.po
+++ b/po/bs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2025-07-11 14:50+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
 "Language-Team: Bosnian <https://hosted.weblate.org/projects/protonplus/"
@@ -1983,7 +1983,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2090,6 +2090,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2205,12 +2210,12 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr "Odaberite željeni alat za kompatibilnost"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Odaberite željeni alat za kompatibilnost"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Alat za kompatibilnost"
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2473,38 +2478,38 @@ msgstr "Ako želite da ubrzam razvoj, obavezno pokažite svoju podršku!"
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Promijenite opcije pokretanja igre"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Opcije za pokretanje"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2610,6 +2615,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Alat za kompatibilnost"
@@ -2618,27 +2624,34 @@ msgstr "Alat za kompatibilnost"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Postavljanje zadanog alata za kompatibilnost"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Opcije za pokretanje"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3548,7 +3561,7 @@ msgstr "Više informacija"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Igre"
@@ -3560,7 +3573,7 @@ msgstr "Igre"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4969,12 +4982,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5345,7 +5358,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5841,7 +5854,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6392,131 +6405,131 @@ msgstr ""
 msgid "Launchers"
 msgstr "Opcije za pokretanje"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Alat za kompatibilnost"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Odaberite profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Glavni izbornik"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Da"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ne"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Otvori u protontricks-u"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Igre"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Nepodržani pokretač"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Instaliraj %s"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Instaliraj %s"
@@ -6730,12 +6743,12 @@ msgstr[0] "Odabrano je %u igara"
 msgstr[1] "Odabrano je %u igara"
 msgstr[2] "Odabrano je %u igara"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Izvlačenje"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/com.vysp3r.ProtonPlus.pot
+++ b/po/com.vysp3r.ProtonPlus.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1949,7 +1949,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2058,6 +2058,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
+
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
 "Steam tool for easy, graphical configuration of your other compatibility "
@@ -2161,11 +2166,11 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr ""
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 msgid "Failed to update compatibilitytool.vdf"
 msgstr ""
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr ""
 
@@ -2341,7 +2346,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr ""
@@ -2419,36 +2424,36 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2542,6 +2547,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr ""
 
@@ -2549,26 +2555,32 @@ msgstr ""
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr ""
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3453,7 +3465,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3464,7 +3476,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4851,12 +4863,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5216,7 +5228,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5688,7 +5700,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6222,124 +6234,124 @@ msgstr ""
 msgid "Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 msgid "Protontricks"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr ""
 
@@ -6538,11 +6550,11 @@ msgid_plural "%d games selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr ""
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-01-11 17:01+0000\n"
 "Last-Translator: Valentin Ljuba <7fnndt50@anonaddy.me>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/protonplus/"
@@ -1974,7 +1974,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Systém"
@@ -2082,6 +2082,11 @@ msgstr "Čínština"
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
 msgstr "Čínština (Tradiční)"
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
@@ -2198,12 +2203,12 @@ msgstr "Přesouvání selhalo"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Selhalo čtení compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Selhalo čtení compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Kompatibilní nástroj"
@@ -2386,7 +2391,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2469,39 +2474,39 @@ msgstr ""
 msgid "Default"
 msgstr "Výchozí"
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 #, fuzzy
 msgid "Filter: Native"
 msgstr "Filtry"
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Filtry"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Možnosti spuštění"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2604,6 +2609,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Kompatibilní nástroj"
@@ -2612,27 +2618,34 @@ msgstr "Kompatibilní nástroj"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Podporované nástroje kompatibility"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Možnosti spuštění"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3540,7 +3553,7 @@ msgstr "Dle systému"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3551,7 +3564,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4964,12 +4977,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Pokročilé"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5357,7 +5370,7 @@ msgid "Tools"
 msgstr "Nástroje"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5842,7 +5855,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr "Síť"
 
@@ -6385,128 +6398,128 @@ msgstr ""
 msgid "Launchers"
 msgstr "Spoušteče"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Kompatibilní nástroj"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Vyber profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Hlavní nabídka"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr "Softwérové proměnné"
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Ano"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ne"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr "Závislosti"
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Otevřít v protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr "Nalezené spouštěče"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Nainstalováno"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr "Nenainstalováno"
 
@@ -6721,12 +6734,12 @@ msgstr[0] "%u her vybráno"
 msgstr[1] "%u her vybráno"
 msgstr[2] "%u her vybráno"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Rozbalování selhalo"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-08-05 08:51+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/protonplus/"
@@ -2028,7 +2028,7 @@ msgstr "%d s"
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "System"
@@ -2136,6 +2136,11 @@ msgstr "Chinesisch"
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (Traditionell)"
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
@@ -2249,11 +2254,11 @@ msgid "Failed to save compatibility tool metadata"
 msgstr ""
 "Metadaten des Kompatibilitätswerkzeugs konnten nicht gespeichert werden"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Compatibilitytool.vdf konnte nicht aktualisiert werden"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr ""
 "Das Manifest des Kompatibilitätswerkzeugs ist ungültig oder unvollständig"
@@ -2445,7 +2450,7 @@ msgstr ""
 msgid "Top face button"
 msgstr "Unten links"
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr "Keine Spiele gefunden"
@@ -2526,36 +2531,36 @@ msgstr ""
 msgid "Default"
 msgstr "Standard"
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr "Filter: Nativ"
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr "Filter: Nicht-Steam"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr "Filter: Alle Spiele"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr "Keine passenden Spiele"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr "Versuchen Sie einen anderen Suchbegriff oder leeren Sie die Suche."
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr "Keine Spiele entsprechen diesem Filter"
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr "Wählen Sie „Alle Spiele“, um Ihre vollständige Bibliothek anzuzeigen."
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr "Für diesen Starter sind keine Spiele verfügbar."
 
@@ -2653,6 +2658,7 @@ msgstr ""
 "lassen die ausgewählten Spiele unverändert."
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr "Kompatibilitätswerkzeug kann nicht angewendet werden"
 
@@ -2662,18 +2668,27 @@ msgstr ""
 "Es wurden keine Spiele geändert, da kein Kompatibilitätswerkzeug ausgewählt "
 "ist."
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr ""
+"Es wurden keine Spiele geändert, da kein Kompatibilitätswerkzeug ausgewählt "
+"ist."
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 "Die ausgewählten Startoptionen sind unvollständig oder werden von diesen "
 "Spielen nicht unterstützt."
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr "Startoptionen können nicht angewendet werden"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
@@ -2681,11 +2696,11 @@ msgstr ""
 "Es wurden keine Spiele geändert, da der Startbefehl nicht sicher vorbereitet "
 "werden konnte."
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr "Stapelaktualisierung fehlgeschlagen"
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3698,7 +3713,7 @@ msgstr "Systemstandard"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3709,7 +3724,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5321,12 +5336,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Erweitert"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr "Experimentell"
 
@@ -5720,7 +5735,7 @@ msgid "Tools"
 msgstr "Werkzeuge"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr "MangoHud"
 
@@ -6240,7 +6255,7 @@ msgid "Media Info"
 msgstr "Medieninformationen"
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr "Netzwerk"
 
@@ -6779,124 +6794,124 @@ msgstr "Ältere Werkzeuge anzeigen, die nicht mehr aktiv gepflegt werden"
 msgid "Launchers"
 msgstr "Starter"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr "Standard-Kompatibilitätswerkzeug"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr "Das Kompatibilitätswerkzeug, das Spiele standardmäßig verwenden"
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr "Ausgewähltes Profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr "Derzeit ausgewähltes Profil für Steam"
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr "API-Tokens"
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr "Proxy-URL"
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr "Beispiel: http://127.0.0.1:7890 oder socks5://127.0.0.1:1080"
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr "Vorschaufunktionen"
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr "Experimentelle Funktionen für frühe Tests aktivieren"
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr "Wartung"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr "Softwareumgebung"
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Ja"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Nein"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr "Flatpak"
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr "Hardware"
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr "HWCAPS"
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr "Abhängigkeiten"
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 msgid "Protontricks"
 msgstr "Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr "Protontricks (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr "MangoHud (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr "Feral GameMode"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr "Erkannte Starter"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Installiert"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr "Nicht installiert"
 
@@ -7105,11 +7120,11 @@ msgid_plural "%d games selected"
 msgstr[0] "%d Spiel ausgewählt"
 msgstr[1] "%d Spiele ausgewählt"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr "Migration fehlgeschlagen"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/el.po
+++ b/po/el.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-04-20 06:09+0000\n"
 "Last-Translator: Xarishark <Xarishark@outlook.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/protonplus/"
@@ -1953,7 +1953,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2062,6 +2062,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
+
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
 "Steam tool for easy, graphical configuration of your other compatibility "
@@ -2166,11 +2171,11 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr ""
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 msgid "Failed to update compatibilitytool.vdf"
 msgstr ""
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr ""
 
@@ -2346,7 +2351,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr ""
@@ -2424,36 +2429,36 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2548,6 +2553,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr ""
 
@@ -2555,26 +2561,32 @@ msgstr ""
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr ""
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3463,7 +3475,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3474,7 +3486,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4869,12 +4881,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5236,7 +5248,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5708,7 +5720,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6242,125 +6254,125 @@ msgstr ""
 msgid "Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "_Σχετικά με το ProtonPlus"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr ""
 
@@ -6559,11 +6571,11 @@ msgid_plural "%d games selected"
 msgstr[0] "Επιλέχθηκε 1 παιχνίδι"
 msgstr[1] "Επιλέχθηκε 1 παιχνίδι"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr ""
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-04-20 13:09+0000\n"
 "Last-Translator: Luis Miguel <luismiguelfm96@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/protonplus/"
@@ -1978,7 +1978,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Sistema"
@@ -2085,6 +2085,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2205,12 +2210,12 @@ msgstr "Moviendo"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Selecciona la herramienta de compatibilidad"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Selecciona la herramienta de compatibilidad"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Herramienta de compatibilidad"
@@ -2392,7 +2397,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2476,39 +2481,39 @@ msgstr "Si quieres que acelere el desarrollo, ¡asegúrate de mostrar tu apoyo!"
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 #, fuzzy
 msgid "Filter: Non-Steam"
 msgstr "SteamOS"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Modificar las opciones de lanzamiento del juego"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Herramientas de lanzamiento"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2611,6 +2616,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Herramienta de compatibilidad"
@@ -2619,27 +2625,34 @@ msgstr "Herramienta de compatibilidad"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Establecer herramienta de compatibilidad por defecto"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Opciones de lanzamiento"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3588,7 +3601,7 @@ msgstr "Más información"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3599,7 +3612,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5065,12 +5078,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Avanzado"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5447,7 +5460,7 @@ msgid "Tools"
 msgstr "Herramientas"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5944,7 +5957,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6504,130 +6517,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "Herramientas de lanzamiento"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Herramienta de compatibilidad"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Seleccionar un perfil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Menú principal"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Sí"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "No"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Abrir en Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Gamescope"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Lanzadores detectados:\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Instalado"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Instalado"
@@ -6842,12 +6855,12 @@ msgid_plural "%d games selected"
 msgstr[0] "%u juegos seleccionados"
 msgstr[1] "%u juegos seleccionados"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Extrayendo"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2025-08-21 19:02+0000\n"
 "Last-Translator: Linus Virtanen <linus.virtanen@protonmail.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/protonplus/"
@@ -1976,7 +1976,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2083,6 +2083,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2199,12 +2204,12 @@ msgstr "Siirretään"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Valitse haluttu yhteensopivuustyökalu"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Valitse haluttu yhteensopivuustyökalu"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Yhteensopivuustyökalu"
@@ -2385,7 +2390,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2467,38 +2472,38 @@ msgstr "Halutessasi nopeampaa kehitystyötä, annathan tukesi!"
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Muokkaa pelin käynnistysasetuksia"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Käynnistysasetukset"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2606,6 +2611,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Yhteensopivuustyökalu"
@@ -2614,27 +2620,34 @@ msgstr "Yhteensopivuustyökalu"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Aseta vakiollinen yhteensopivuustyökalu"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Käynnistysasetukset"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3544,7 +3557,7 @@ msgstr "Lisätietoja"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Pelit"
@@ -3556,7 +3569,7 @@ msgstr "Pelit"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4965,12 +4978,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5345,7 +5358,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5838,7 +5851,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6389,131 +6402,131 @@ msgstr ""
 msgid "Launchers"
 msgstr "Käynnistysasetukset"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Yhteensopivuustyökalu"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Valitse profiili"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Päävalikko"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Kyllä"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ei"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Avaa Protontricks:issä"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Pelit"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Tämä käynnistin ei ole tuettu"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Asenna %s"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Asenna %s"
@@ -6727,12 +6740,12 @@ msgid_plural "%d games selected"
 msgstr[0] "%u pelit valittu"
 msgstr[1] "%u pelit valittu"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Puretaan"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-05-10 19:11+0000\n"
 "Last-Translator: Badreddine-Rezzouk <badreddinerezzouk@protonmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/protonplus/"
@@ -1989,7 +1989,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Système"
@@ -2096,6 +2096,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2215,12 +2220,12 @@ msgstr "Déplacement"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Sélectionner votre outil de compatibilité"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Sélectionner votre outil de compatibilité"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Outil de compatibilité"
@@ -2404,7 +2409,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2485,37 +2490,37 @@ msgstr "Envie d'accélérer le développement ? Montrez votre soutien !"
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Paramètres du launcher"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2619,6 +2624,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Outil de compatibilité"
@@ -2627,27 +2633,34 @@ msgstr "Outil de compatibilité"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Définir l'outil de compatibilité par défaut"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Paramètres du launcher"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3566,7 +3579,7 @@ msgstr "Plus d'informations"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Jeux"
@@ -3578,7 +3591,7 @@ msgstr "Jeux"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4996,12 +5009,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5381,7 +5394,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5873,7 +5886,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6422,130 +6435,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "Paramètres du launcher"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Définir l'outil de compatibilité par défaut"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Sélectionner un profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Menu principal"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Oui"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Non"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Ouvrir dans protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Jeux"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Launcher non supporté"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Installés seulement"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Installés seulement"
@@ -6759,12 +6772,12 @@ msgid_plural "%d games selected"
 msgstr[0] "%u jeux sélectionnés"
 msgstr[1] "%u jeux sélectionnés"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Extraction"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2025-07-11 14:50+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/protonplus/"
@@ -1986,7 +1986,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2093,6 +2093,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2208,12 +2213,12 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr "Odaberite željeni alat za kompatibilnost"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Odaberite željeni alat za kompatibilnost"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Alat za kompatibilnost"
@@ -2394,7 +2399,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2476,38 +2481,38 @@ msgstr "Ako želite da ubrzam razvoj, svakako pokažite svoju podršku!"
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Promijenite opcije pokretanja igre"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Opcije pokretanja"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2613,6 +2618,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Alat za kompatibilnost"
@@ -2621,27 +2627,34 @@ msgstr "Alat za kompatibilnost"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Postavljanje zadanog alata za kompatibilnost"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Opcije pokretanja"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3551,7 +3564,7 @@ msgstr "Više Informacija"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Igre"
@@ -3563,7 +3576,7 @@ msgstr "Igre"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4972,12 +4985,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5348,7 +5361,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5844,7 +5857,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6395,131 +6408,131 @@ msgstr ""
 msgid "Launchers"
 msgstr "Opcije pokretanja"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Alat za kompatibilnost"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Odaberite profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Glavni izbornik"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Da"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ne"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Otvori u protontricks-u"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Igre"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Nepodržani pokretač"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Instaliraj %s"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Instaliraj %s"
@@ -6733,12 +6746,12 @@ msgstr[0] "Odabrano je %u igara"
 msgstr[1] "Odabrano je %u igara"
 msgstr[2] "Odabrano je %u igara"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Izvlačenje"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/id.po
+++ b/po/id.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-04-12 17:09+0000\n"
 "Last-Translator: Arif Budiman <arifpedia@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/protonplus/"
@@ -1986,7 +1986,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Sistem"
@@ -2093,6 +2093,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2212,12 +2217,12 @@ msgstr "Memindahkan"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Pilih alat kompatibilitas yang Anda inginkan"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Pilih alat kompatibilitas yang Anda inginkan"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Alat kompatibilitas"
@@ -2400,7 +2405,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2484,38 +2489,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Ubah opsi peluncuran game"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Alat peluncuran"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2616,6 +2621,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Alat kompatibilitas"
@@ -2624,27 +2630,34 @@ msgstr "Alat kompatibilitas"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Atur alat kompatibilitas default"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Opsi peluncuran"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3579,7 +3592,7 @@ msgstr "Informasi selengkapnya"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3590,7 +3603,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5044,12 +5057,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Lanjutan"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5428,7 +5441,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5919,7 +5932,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6478,130 +6491,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "Alat peluncuran"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Alat kompatibilitas"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Pilih profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Menu Utama"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Ya"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Tidak"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Buka di protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Gamescope"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Peluncur terdeteksi:\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Terinstal"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Terinstal"
@@ -6815,12 +6828,12 @@ msgid "%d game selected"
 msgid_plural "%d games selected"
 msgstr[0] "%u game dipilih"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Mengekstrak"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-08-05 16:05+0200\n"
 "Last-Translator: Youseffo13 <>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/protonplus/"
@@ -2068,7 +2068,7 @@ msgstr "%ds"
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Sistema"
@@ -2176,6 +2176,11 @@ msgstr "Cinese"
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
 msgstr "Cinese (tradizionale)"
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
@@ -2288,11 +2293,11 @@ msgstr "Spostamento fallito"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Impossibile salvare i metadati dello strumento di compatibilità"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Impossibile aggiornare compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr ""
 "Il manifest dello strumento di compatibilità non è valido o è incompleto"
@@ -2488,7 +2493,7 @@ msgstr ""
 msgid "Top face button"
 msgstr "In basso a sinistra"
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr "Nessun gioco trovato"
@@ -2567,36 +2572,36 @@ msgstr "Se vuoi che acceleri lo sviluppo, mostra il tuo supporto!"
 msgid "Default"
 msgstr "Predefinito"
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr "Filtro: Nativo"
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr "Filtro: Non-Steam"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr "Filtro: Tutti i giochi"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr "Nessun gioco corrispondente"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr "Prova un termine di ricerca diverso o svuota la ricerca."
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr "Nessun gioco corrisponde a questo filtro"
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr "Scegli Tutti i giochi per vedere la tua libreria completa."
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr "Nessun gioco è disponibile per questo launcher."
 
@@ -2694,6 +2699,7 @@ msgstr ""
 "giochi selezionati invariati."
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr "Impossibile applicare lo strumento di Compatibilità"
 
@@ -2703,18 +2709,27 @@ msgstr ""
 "Nessun gioco è stato modificato perché non è stato selezionato alcuno "
 "strumento di compatibilità."
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr ""
+"Nessun gioco è stato modificato perché non è stato selezionato alcuno "
+"strumento di compatibilità."
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 "Le opzioni di lancio selezionate sono incomplete o non supportate per questi "
 "giochi."
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr "Impossibile applicare le opzioni di lancio"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
@@ -2722,11 +2737,11 @@ msgstr ""
 "Nessun gioco è stato modificato perché il comando di lancio non poteva "
 "essere preparato in sicurezza."
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr "Aggiornamento in blocco non riuscito"
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3728,7 +3743,7 @@ msgstr "Predefinito di sistema"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3739,7 +3754,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5323,12 +5338,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Avanzate"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr "Sperimentale"
 
@@ -5716,7 +5731,7 @@ msgid "Tools"
 msgstr "Strumenti"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr "MangoHud"
 
@@ -6227,7 +6242,7 @@ msgid "Media Info"
 msgstr "Info supporto"
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr "Rete"
 
@@ -6764,126 +6779,126 @@ msgstr "Mostra gli strumenti più vecchi che non sono più mantenuti attivamente
 msgid "Launchers"
 msgstr "Launcher"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr "Strumento di compatibilità predefinito"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 "Lo strumento di compatibilità che i giochi utilizzeranno per impostazione "
 "predefinita"
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr "Profilo selezionato"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr "Profilo attualmente selezionato per Steam"
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr "Token API"
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr "URL proxy"
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr "Esempio: http://127.0.0.1:7890 o socks5://127.0.0.1:1080"
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr "Funzionalità in anteprima"
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr "Abilita funzionalità sperimentali per test anticipati"
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr "Manutenzione"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr "Ambiente software"
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Sì"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "No"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr "Flatpak"
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr "Hardware"
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr "HWCAPS"
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr "Dipendenze"
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 msgid "Protontricks"
 msgstr "Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr "Protontricks (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr "MangoHud (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr "Feral Gamemode"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr "Launcher Rilevati"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Installati"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr "Non installati"
 
@@ -7091,11 +7106,11 @@ msgid_plural "%d games selected"
 msgstr[0] "%d gioco selezionato"
 msgstr[1] "%d giochi selezionati"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr "Migrazione Fallita"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-04-20 20:09+0000\n"
 "Last-Translator: camegone <kuroneko0308kw@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/protonplus/"
@@ -1979,7 +1979,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "システム"
@@ -2086,6 +2086,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2205,12 +2210,12 @@ msgstr "移動中"
 msgid "Failed to save compatibility tool metadata"
 msgstr "使用したい互換性ツールを選択"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "使用したい互換性ツールを選択"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "互換性ツール"
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2476,38 +2481,38 @@ msgstr "開発をスピードアップしてほしい場合は、私を支援し
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "ゲームの起動オプションを変更"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "起動ツール"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2607,6 +2612,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "互換性ツール"
@@ -2615,27 +2621,34 @@ msgstr "互換性ツール"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "デフォルトの互換性ツールを設定する"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "起動オプション"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3579,7 +3592,7 @@ msgstr "詳細情報"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3590,7 +3603,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -5043,12 +5056,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "上級"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5422,7 +5435,7 @@ msgid "Tools"
 msgstr "ツール"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5913,7 +5926,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6467,130 +6480,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "起動ツール"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "互換性ツール"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "プロファイルを選択"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "メインメニュー"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "はい"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "いいえ"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "protontricks で開く"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "ゲーム"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "ランチャーを検出しました:\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "インストール済み"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "インストール済み"
@@ -6804,12 +6817,12 @@ msgid "%d game selected"
 msgid_plural "%d games selected"
 msgstr[0] "%u つのゲームを選択済み"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "展開中"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/ka.po
+++ b/po/ka.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-01-09 12:01+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <https://hosted.weblate.org/projects/protonplus/"
@@ -1983,7 +1983,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "სისტემა"
@@ -2090,6 +2090,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2209,12 +2214,12 @@ msgstr "გადატანა"
 msgid "Failed to save compatibility tool metadata"
 msgstr "აირჩიეთ სასურველი თავსებადობის ხელსაწყო"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "აირჩიეთ სასურველი თავსებადობის ხელსაწყო"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "თავსებადობის ხელსაწყო"
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2481,38 +2486,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "თამაშის გაშვების პარამეტრების შეცვლა"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "გაშვების მორგება"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2616,6 +2621,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "თავსებადობის ხელსაწყო"
@@ -2624,27 +2630,34 @@ msgstr "თავსებადობის ხელსაწყო"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "აირჩიეთ ნაგულისხმევი თავსებადობის ხელსაწყო"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "გაშვების მორგება"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3554,7 +3567,7 @@ msgstr "მეტი ინფორმაცია"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "თამაშები"
@@ -3566,7 +3579,7 @@ msgstr "თამაშები"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4976,12 +4989,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5361,7 +5374,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5853,7 +5866,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6403,130 +6416,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "გაშვების მორგება"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "თავსებადობის ხელსაწყო"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "აირჩიეთ პროფილი"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "მთავარი მენიუ"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "დიახ"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "არა"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "გახსნა protontricks-ში"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "თამაშები"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "მხარდაუჭერელი გამშვები"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "დაყენებულია"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "დაყენებულია"
@@ -6741,12 +6754,12 @@ msgid_plural "%d games selected"
 msgstr[0] "მონიშნულია %u თამაში"
 msgstr[1] "მონიშნულია %u თამაში"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "ამოღება"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2025-07-21 02:03+0000\n"
 "Last-Translator: WeAreGeek <weblate@wearegeek.nl>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/protonplus/"
@@ -1981,7 +1981,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2088,6 +2088,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2204,12 +2209,12 @@ msgstr "Verplaatsen"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Selecteer het gewenste compatibiliteitshulpmiddel"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Selecteer het gewenste compatibiliteitshulpmiddel"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Compatibiliteitstool"
@@ -2390,7 +2395,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2473,38 +2478,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "De opstartopties van het spel aanpassen"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Lanceeropties"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2616,6 +2621,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Compatibiliteitstool"
@@ -2624,27 +2630,34 @@ msgstr "Compatibiliteitstool"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Standaard compatibiliteitstool instellen"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Lanceeropties"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3554,7 +3567,7 @@ msgstr "Meer informatie"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Spellen"
@@ -3566,7 +3579,7 @@ msgstr "Spellen"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4975,12 +4988,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5355,7 +5368,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5848,7 +5861,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6399,131 +6412,131 @@ msgstr ""
 msgid "Launchers"
 msgstr "Lanceeropties"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Compatibiliteitstool"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Selecteer een profiel"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Hoofdmenu"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Ja"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Nee"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Open in protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Spellen"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Niet ondersteunde launcher"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Installeer %s"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Installeer %s"
@@ -6739,12 +6752,12 @@ msgid_plural "%d games selected"
 msgstr[0] "%u spellen geselecteerd"
 msgstr[1] "%u spellen geselecteerd"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Uitpakken"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-05-12 01:11+0000\n"
 "Last-Translator: Jakub Szymański <99kuba11@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/protonplus/"
@@ -1984,7 +1984,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "System"
@@ -2091,6 +2091,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2211,12 +2216,12 @@ msgstr "Przenoszenie"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Wybierz żądane narzędzie zgodności"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Wybierz żądane narzędzie zgodności"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Narzędzie zgodności"
@@ -2400,7 +2405,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2485,38 +2490,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 #, fuzzy
 msgid "Filter: Non-Steam"
 msgstr "SteamOS"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Parametry startowe"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2619,6 +2624,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Narzędzie zgodności"
@@ -2627,27 +2633,34 @@ msgstr "Narzędzie zgodności"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Ustaw domyślne narzędzie zgodności"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Parametry startowe"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3560,7 +3573,7 @@ msgstr "Więcej informacji"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3571,7 +3584,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -4990,12 +5003,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Zaawansowane"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5374,7 +5387,7 @@ msgid "Tools"
 msgstr "Narzędzia"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5872,7 +5885,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6422,130 +6435,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "Parametry startowe"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Ustaw domyślne narzędzie zgodności"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Wybierz profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Menu główne"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Tak"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Nie"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Otwórz w protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Gamescope"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Wykryte uruchamiacze:\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Zainstalowane"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Zainstalowane"
@@ -6760,12 +6773,12 @@ msgstr[0] "wybrano %u gier"
 msgstr[1] "wybrano %u gier"
 msgstr[2] "wybrano %u gier"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Wyodrębnianie"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/pt.po
+++ b/po/pt.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-05-15 06:11+0000\n"
 "Last-Translator: Yasmin Stanchese <yasmin@snowfloke.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/protonplus/"
@@ -1988,7 +1988,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Sistema"
@@ -2095,6 +2095,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2214,12 +2219,12 @@ msgstr "Movendo"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Selecione sua ferramenta de compatibilidade desejada"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Selecione sua ferramenta de compatibilidade desejada"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Ferramenta de compatibilidade"
@@ -2403,7 +2408,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2488,38 +2493,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 #, fuzzy
 msgid "Filter: Non-Steam"
 msgstr "SteamOS"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Opções de inicialização"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2629,6 +2634,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Ferramenta de compatibilidade"
@@ -2637,27 +2643,34 @@ msgstr "Ferramenta de compatibilidade"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Definir ferramenta de compatibilidade padrão"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Opções de lançamento"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3581,7 +3594,7 @@ msgstr "Mais informação"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Jogos"
@@ -3593,7 +3606,7 @@ msgstr "Jogos"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -5019,12 +5032,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Avançado"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5403,7 +5416,7 @@ msgid "Tools"
 msgstr "Ferramentas"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5897,7 +5910,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6452,131 +6465,131 @@ msgstr ""
 msgid "Launchers"
 msgstr "Opções de inicialização"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Definir ferramenta de compatibilidade padrão"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Selecione um perfil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Menu Principal"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Sim"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Não"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Abrir em Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Jogos"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Inicializadores detectados:\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Instalados"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Instalados"
@@ -6792,12 +6805,12 @@ msgid_plural "%d games selected"
 msgstr[0] "%u jogos selecionados"
 msgstr[1] "%u jogos selecionados"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Extraindo"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2025-11-30 21:00+0000\n"
 "Last-Translator: serg <serhii.maleev@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/protonplus/"
@@ -1982,7 +1982,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Системная"
@@ -2089,6 +2089,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2208,12 +2213,12 @@ msgstr "Перемещение"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Выберите желаемый инструмент совместимости"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Выберите желаемый инструмент совместимости"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Инструмент совместимости"
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2478,38 +2483,38 @@ msgstr "Если хотите ускорить разработку, подде�
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Изменить параметры запуска игры"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Настройки лаунчера"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2615,6 +2620,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Инструмент совместимости"
@@ -2623,27 +2629,34 @@ msgstr "Инструмент совместимости"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Установить инструмент совместимости по умолчанию"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Настройки лаунчера"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3555,7 +3568,7 @@ msgstr "Больше информации"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Игры"
@@ -3567,7 +3580,7 @@ msgstr "Игры"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4977,12 +4990,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5363,7 +5376,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5859,7 +5872,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6409,130 +6422,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "Настройки лаунчера"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Инструмент совместимости"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Выберите профиль"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Основное меню"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Да"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Нет"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Открыть в protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Игры"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Неподдерживаемый лаунчер"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Установленные"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Установленные"
@@ -6748,12 +6761,12 @@ msgstr[0] "%u выбранных игр"
 msgstr[1] "%u выбранных игр"
 msgstr[2] "%u выбранных игр"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Распаковывается..."
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/sk.po
+++ b/po/sk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-05-24 00:30+0000\n"
 "Last-Translator: Gemini AI\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/protonplus/"
@@ -2030,7 +2030,7 @@ msgstr "%ds"
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Systém"
@@ -2138,6 +2138,11 @@ msgstr "Čínština"
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
 msgstr "Čínština (Tradiční)"
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
@@ -2255,12 +2260,12 @@ msgstr "Presúvanie zlyhalo"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Nepodarilo sa prečítať súbor compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Nepodarilo sa prečítať súbor compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Nástroj kompatibility, ktorý hry použijú automaticky ako predvolený"
@@ -2452,7 +2457,7 @@ msgstr ""
 msgid "Top face button"
 msgstr "Dole vľavo"
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2534,41 +2539,41 @@ msgstr "Ak chcete, aby som urýchlil vývoj, nezabudnite vyjadriť svoju podporu
 msgid "Default"
 msgstr "Výchozí"
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 #, fuzzy
 msgid "Filter: Native"
 msgstr "Filtry"
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 #, fuzzy
 msgid "Filter: Non-Steam"
 msgstr "Mimo Steamu"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Filtry"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Nástroje spustenia"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 #, fuzzy
 msgid "No games match this filter"
 msgstr "Žiadne verzie nezodpovedajú aktuálnemu filtru."
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2671,6 +2676,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Nástroj kompatibility nebol nájdený"
@@ -2679,27 +2685,34 @@ msgstr "Nástroj kompatibility nebol nájdený"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Podporované nástroje kompatibility:"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Možnosti spuštění"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr "Hromadná aktualizácia zlyhala"
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3679,7 +3692,7 @@ msgstr "Dle systému"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3690,7 +3703,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5181,12 +5194,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Pokročilé"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr "Experimentálne"
 
@@ -5566,7 +5579,7 @@ msgid "Tools"
 msgstr "Nástroje"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr "MangoHud"
 
@@ -6052,7 +6065,7 @@ msgid "Media Info"
 msgstr "Informácie o médiách"
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr "Síť"
 
@@ -6598,129 +6611,129 @@ msgstr "Zobrazovať staršie nástroje, ktoré už nie sú aktívne vyvíjané"
 msgid "Launchers"
 msgstr "Spúšťače"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Predvolený nástroj kompatibility"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr "Nástroj kompatibility, ktorý hry použijú automaticky ako predvolený"
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Vyber profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr "API tokeny"
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr "Ukážkové funkcie"
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr "Povoliť experimentálne funkcie pre včasné testovanie"
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Údržba"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr "Softwérové proměnné"
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Ano"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ne"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr "Flatpak"
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr "Hardvér"
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr "HWCAPS"
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr "Závislosti"
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr "Protontricks (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr "MangoHud (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "GameMode"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr "Nalezené spouštěče"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Nainstalováno"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr "Nenainstalováno"
 
@@ -6941,12 +6954,12 @@ msgstr[0] "%d vybraná hra"
 msgstr[1] "%d vybrané hry"
 msgstr[2] "%d vybraných hier"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Rozbalenie zlyhalo"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 #, fuzzy
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2025-07-11 14:50+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
 "Language-Team: Serbian (Latin script) <https://hosted.weblate.org/projects/"
@@ -1987,7 +1987,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2094,6 +2094,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2209,12 +2214,12 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr "Izaberite željeni alat za kompatibilnost"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Izaberite željeni alat za kompatibilnost"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Alat za kompatibilnost"
@@ -2395,7 +2400,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2478,38 +2483,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "Promenite opcije pokretanja igara"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Opcije pokretanja"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2615,6 +2620,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Alat za kompatibilnost"
@@ -2623,27 +2629,34 @@ msgstr "Alat za kompatibilnost"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Podešavanje podrazumevanog alata za kompatibilnost"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Opcije pokretanja"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3553,7 +3566,7 @@ msgstr "Više Informacija"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 #, fuzzy
 msgid "Gamescope"
 msgstr "Igre"
@@ -3565,7 +3578,7 @@ msgstr "Igre"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4974,12 +4987,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5350,7 +5363,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5846,7 +5859,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6397,131 +6410,131 @@ msgstr ""
 msgid "Launchers"
 msgstr "Opcije pokretanja"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Alat za kompatibilnost"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Izaberite profil"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Glavni meni"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Da"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ne"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Otvorite u protontricks-u"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Igre"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Nepodržani lanser"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Instalirajte %s"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Instalirajte %s"
@@ -6735,12 +6748,12 @@ msgstr[0] "Odabrano je %u igara"
 msgstr[1] "Odabrano je %u igara"
 msgstr[2] "Odabrano je %u igara"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Izvlačenje"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2024-10-03 01:10+0200\n"
 "Last-Translator: Johnny Arcitec <Arcitec@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/protonplus/"
@@ -1977,7 +1977,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2084,6 +2084,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2197,12 +2202,12 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr "En modern kompatibilitetsverktygshanterare för Linux."
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "En modern kompatibilitetsverktygshanterare för Linux."
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "En modern kompatibilitetsverktygshanterare för Linux."
@@ -2381,7 +2386,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr ""
@@ -2460,36 +2465,36 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2585,6 +2590,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "En modern kompatibilitetsverktygshanterare för Linux."
@@ -2593,27 +2599,34 @@ msgstr "En modern kompatibilitetsverktygshanterare för Linux."
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "En modern kompatibilitetsverktygshanterare för Linux."
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Visa mer information"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3510,7 +3523,7 @@ msgstr "Visa mer information"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3521,7 +3534,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4925,12 +4938,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5296,7 +5309,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5781,7 +5794,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6327,128 +6340,128 @@ msgstr ""
 msgid "Launchers"
 msgstr "Visa mer information"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "En modern kompatibilitetsverktygshanterare för Linux."
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Ja"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Nej"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "_Om ProtonPlus"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Visa mer information"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 #, fuzzy
 msgid "Installed"
 msgstr "Installera %s"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Installera %s"
@@ -6657,12 +6670,12 @@ msgid_plural "%d games selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Installationen kommer att avbrytas."
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-04-28 02:09+0000\n"
 "Last-Translator: Димко <Dymkovych@proton.me>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/protonplus/"
@@ -1977,7 +1977,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "Системна"
@@ -2084,6 +2084,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2203,12 +2208,12 @@ msgstr "Переміщення"
 msgid "Failed to save compatibility tool metadata"
 msgstr "Виберіть бажаний інструмент сумісності"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "Виберіть бажаний інструмент сумісності"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "Інструмент сумісності"
@@ -2392,7 +2397,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2476,38 +2481,38 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 #, fuzzy
 msgid "Filter: Non-Steam"
 msgstr "SteamOS"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "Інструменти запуску"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2612,6 +2617,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "Інструмент сумісності"
@@ -2620,27 +2626,34 @@ msgstr "Інструмент сумісності"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "Типовий інструмент сумісності"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "Параметри запуску"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3582,7 +3595,7 @@ msgstr "Більше інформації"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3593,7 +3606,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5056,12 +5069,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "Розширені"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5441,7 +5454,7 @@ msgid "Tools"
 msgstr "Інструменти"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5941,7 +5954,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6497,130 +6510,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "Інструменти запуску"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "Типовий інструмент сумісності"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "Оберіть профіль"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "Головне меню"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "Так"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "Ні"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "Відкрити в protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Gamescope"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "Виявлені запускачі:\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "Встановлені"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "Встановлені"
@@ -6835,12 +6848,12 @@ msgstr[0] "Вибрано %u ігор"
 msgstr[1] "Вибрано %u ігор"
 msgstr[2] "Вибрано %u ігор"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "Витягання"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-02-16 17:22-0500\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1948,7 +1948,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr ""
@@ -2057,6 +2057,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
+
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
 "Steam tool for easy, graphical configuration of your other compatibility "
@@ -2160,11 +2165,11 @@ msgstr ""
 msgid "Failed to save compatibility tool metadata"
 msgstr ""
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 msgid "Failed to update compatibilitytool.vdf"
 msgstr ""
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr ""
 
@@ -2340,7 +2345,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr ""
@@ -2418,36 +2423,36 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2539,6 +2544,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr ""
 
@@ -2546,26 +2552,32 @@ msgstr ""
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr ""
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3450,7 +3462,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr ""
 
@@ -3461,7 +3473,7 @@ msgstr ""
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr ""
 
@@ -4848,12 +4860,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr ""
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5212,7 +5224,7 @@ msgid "Tools"
 msgstr ""
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5680,7 +5692,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6214,124 +6226,124 @@ msgstr ""
 msgid "Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 msgid "Protontricks"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr ""
 
@@ -6529,11 +6541,11 @@ msgid "%d game selected"
 msgid_plural "%d games selected"
 msgstr[0] ""
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr ""
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-08-07 23:07+0800\n"
 "Last-Translator: Markson Hosben <marksonhosben@proton.me>\n"
 "Language-Team: Chinese <>\n"
@@ -1968,7 +1968,7 @@ msgstr "%d秒"
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "系统"
@@ -2077,6 +2077,11 @@ msgstr "中文"
 msgid "Chinese (Traditional)"
 msgstr "中文（繁体）"
 
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
+msgstr ""
+
 #: src/models/tools/steamtinkerlaunch.vala:8
 msgid ""
 "Steam tool for easy, graphical configuration of your other compatibility "
@@ -2182,11 +2187,11 @@ msgstr "移动失败"
 msgid "Failed to save compatibility tool metadata"
 msgstr "无法保存兼容性工具元数据"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "无法更新 compatibilitytool.vdf"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "兼容性工具清单无效或不完整。"
 
@@ -2365,7 +2370,7 @@ msgstr "上"
 msgid "Top face button"
 msgstr "上方正面按键"
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 msgid "No games found"
 msgstr "未找到游戏"
@@ -2444,36 +2449,36 @@ msgstr "如果你想让我加快开发进度，请务必表达你的支持！"
 msgid "Default"
 msgstr "默认"
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr "筛选：原生"
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 msgid "Filter: Non-Steam"
 msgstr "过滤器：非Steam"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 msgid "Filter: All games"
 msgstr "筛选：全部游戏"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 msgid "No matching games"
 msgstr "没有匹配的游戏"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr "尝试其他搜索词或清除搜索。"
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr "没有游戏符合此筛选条件"
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr "选择“全部游戏”以查看完整库。"
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr "此启动器没有可用游戏。"
 
@@ -2565,6 +2570,7 @@ msgid ""
 msgstr "启用您要更改的区块。被禁用的区块不会修改所选游戏。"
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 msgid "Compatibility tool cannot be applied"
 msgstr "无法应用兼容性工具"
 
@@ -2572,26 +2578,33 @@ msgstr "无法应用兼容性工具"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr "未选择兼容性工具，因此没有游戏被更改。"
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "未选择兼容性工具，因此没有游戏被更改。"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr "所选启动选项不完整或不受这些游戏支持。"
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 msgid "Launch options cannot be applied"
 msgstr "无法应用启动选项"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr "无法安全准备启动命令，因此没有游戏被更改。"
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr "批量更新失败"
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3523,7 +3536,7 @@ msgstr "系统默认"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3534,7 +3547,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -4984,12 +4997,12 @@ msgstr "保持无法识别、带引号及不透明的 Shell 内容与加载时�
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "高级"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr "实验性"
 
@@ -5362,7 +5375,7 @@ msgid "Tools"
 msgstr "工具"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr "MangoHud"
 
@@ -5848,7 +5861,7 @@ msgid "Media Info"
 msgstr "媒体信息"
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr "网络"
 
@@ -6382,124 +6395,124 @@ msgstr "显示不再积极维护的旧版本兼容工具。"
 msgid "Launchers"
 msgstr "启动器"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 msgid "Default compatibility tool"
 msgstr "默认兼容性工具"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr "游戏将会默认使用的兼容性工具"
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 msgid "Selected profile"
 msgstr "选择的个人资料"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr "当前选择的 Steam 个人资料"
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr "API 令牌"
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr "代理 URL"
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr "如：http://127.0.0.1:7890 或 socks5://127.0.0.1:1080"
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr "预览功能"
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr "启用实验性功能以便尽早测试"
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 msgid "Maintenance"
 msgstr "维护"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr "软件环境"
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "是"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "否"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr "Flatpak"
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr "硬件"
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr "HWCAPS"
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr "依赖项"
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 msgid "Protontricks"
 msgstr "Protontricks"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr "Protontricks (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr "MangoHud (Flatpak)"
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 msgid "Feral Gamemode"
 msgstr "Feral Gamemode"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 msgid "Detected Launchers"
 msgstr "检测到的启动器"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "已安装"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 msgid "Not installed"
 msgstr "未安装"
 
@@ -6699,11 +6712,11 @@ msgid "%d game selected"
 msgid_plural "%d games selected"
 msgstr[0] "已选择 %d 款游戏"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 msgid "Migration Failed"
 msgstr "迁移失败"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.vysp3r.ProtonPlus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 10:43-0400\n"
+"POT-Creation-Date: 2026-08-09 11:57-0400\n"
 "PO-Revision-Date: 2026-04-19 00:59+0800\n"
 "Last-Translator: nick.exe <nick.exe@gmail.com>\n"
 "Language-Team: CodeBay.IN\n"
@@ -1973,7 +1973,7 @@ msgstr ""
 
 #. System Page
 #: src/globals.vala:30 src/widgets/mangohud/mangohud-extras-page.vala:74
-#: src/widgets/preferences/preferences-dialog.vala:302
+#: src/widgets/preferences/preferences-dialog.vala:303
 #: src/widgets/preferences/preferences-theme-row.vala:15
 msgid "System"
 msgstr "系統"
@@ -2080,6 +2080,11 @@ msgstr ""
 
 #: src/globals.vala:56
 msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/models/launchers/steam.vala:356
+#, c-format
+msgid "%s (Unavailable)"
 msgstr ""
 
 #: src/models/tools/steamtinkerlaunch.vala:8
@@ -2199,12 +2204,12 @@ msgstr "正在搬移"
 msgid "Failed to save compatibility tool metadata"
 msgstr "選擇所需的相容性工具"
 
-#: src/services/standard-archive-workflow.vala:331
+#: src/services/standard-archive-workflow.vala:334
 #, fuzzy
 msgid "Failed to update compatibilitytool.vdf"
 msgstr "選擇所需的相容性工具"
 
-#: src/services/standard-archive-workflow.vala:348
+#: src/services/standard-archive-workflow.vala:351
 #, fuzzy
 msgid "The compatibility tool manifest is invalid or incomplete"
 msgstr "相容性工具"
@@ -2387,7 +2392,7 @@ msgstr ""
 msgid "Top face button"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:494
+#: src/widgets/games/games-box.vala:75 src/widgets/games/games-box.vala:500
 #: src/widgets/tools/tools-release-box.vala:102
 #, fuzzy
 msgid "No games found"
@@ -2471,39 +2476,39 @@ msgstr "若希望我加快開發速度，請務必表達您的支持！"
 msgid "Default"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:462
+#: src/widgets/games/games-box.vala:468
 msgid "Filter: Native"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:464
+#: src/widgets/games/games-box.vala:470
 #, fuzzy
 msgid "Filter: Non-Steam"
 msgstr "SteamOS"
 
-#: src/widgets/games/games-box.vala:466
+#: src/widgets/games/games-box.vala:472
 #, fuzzy
 msgid "Filter: All games"
 msgstr "修改遊戲啟動選項"
 
-#: src/widgets/games/games-box.vala:486
+#: src/widgets/games/games-box.vala:492
 #, fuzzy
 msgid "No matching games"
 msgstr "啟動工具"
 
-#: src/widgets/games/games-box.vala:487
+#: src/widgets/games/games-box.vala:493
 #: src/widgets/tools/tools-group-box.vala:170
 msgid "Try a different search term or clear the search."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:490
+#: src/widgets/games/games-box.vala:496
 msgid "No games match this filter"
 msgstr ""
 
-#: src/widgets/games/games-box.vala:491
+#: src/widgets/games/games-box.vala:497
 msgid "Choose All games to see your complete library."
 msgstr ""
 
-#: src/widgets/games/games-box.vala:495
+#: src/widgets/games/games-box.vala:501
 msgid "No games are available for this launcher."
 msgstr ""
 
@@ -2602,6 +2607,7 @@ msgid ""
 msgstr ""
 
 #: src/widgets/games/games-mass-edit-view.vala:268
+#: src/widgets/games/games-mass-edit-view.vala:279
 #, fuzzy
 msgid "Compatibility tool cannot be applied"
 msgstr "相容性工具"
@@ -2610,27 +2616,34 @@ msgstr "相容性工具"
 msgid "No games were changed because no compatibility tool is selected."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:291
+#: src/widgets/games/games-mass-edit-view.vala:280
+#, fuzzy
+msgid ""
+"No games were changed because the selected compatibility tool is no longer "
+"available."
+msgstr "設定預設相容性工具"
+
+#: src/widgets/games/games-mass-edit-view.vala:306
 msgid ""
 "The selected launch options are incomplete or unsupported for these games."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:292
+#: src/widgets/games/games-mass-edit-view.vala:307
 #, fuzzy
 msgid "Launch options cannot be applied"
 msgstr "啟動選項"
 
-#: src/widgets/games/games-mass-edit-view.vala:293
+#: src/widgets/games/games-mass-edit-view.vala:308
 msgid ""
 "No games were changed because the launch command could not be prepared "
 "safely."
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:344
+#: src/widgets/games/games-mass-edit-view.vala:359
 msgid "Batch Update Failed"
 msgstr ""
 
-#: src/widgets/games/games-mass-edit-view.vala:345
+#: src/widgets/games/games-mass-edit-view.vala:360
 msgid ""
 "Some games could not be updated with the new compatibility tool or launch "
 "options. This may be due to missing permissions or file access issues."
@@ -3563,7 +3576,7 @@ msgstr "更多資訊"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1251
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1252
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1253
-#: src/widgets/preferences/preferences-dialog.vala:365
+#: src/widgets/preferences/preferences-dialog.vala:366
 msgid "Gamescope"
 msgstr "Gamescope"
 
@@ -3574,7 +3587,7 @@ msgstr "Gamescope"
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1257
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1258
 #: src/widgets/games/launch-options-editor/launch-options-option-catalog.vala:1259
-#: src/widgets/preferences/preferences-dialog.vala:370
+#: src/widgets/preferences/preferences-dialog.vala:371
 msgid "ScopeBuddy"
 msgstr "ScopeBuddy"
 
@@ -5027,12 +5040,12 @@ msgstr ""
 #. Advanced Page
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:40
 #: src/widgets/mangohud/mangohud-box.vala:69
-#: src/widgets/preferences/preferences-dialog.vala:236
+#: src/widgets/preferences/preferences-dialog.vala:237
 msgid "Advanced"
 msgstr "進階"
 
 #: src/widgets/games/launch-options-editor/launch-options-presentation-registry.vala:42
-#: src/widgets/preferences/preferences-dialog.vala:281
+#: src/widgets/preferences/preferences-dialog.vala:282
 msgid "Experimental"
 msgstr ""
 
@@ -5406,7 +5419,7 @@ msgid "Tools"
 msgstr "工具"
 
 #: src/widgets/main/main-box.vala:48
-#: src/widgets/preferences/preferences-dialog.vala:355
+#: src/widgets/preferences/preferences-dialog.vala:356
 msgid "MangoHud"
 msgstr ""
 
@@ -5898,7 +5911,7 @@ msgid "Media Info"
 msgstr ""
 
 #: src/widgets/mangohud/mangohud-extras-page.vala:130
-#: src/widgets/preferences/preferences-dialog.vala:263
+#: src/widgets/preferences/preferences-dialog.vala:264
 msgid "Network"
 msgstr ""
 
@@ -6456,130 +6469,130 @@ msgstr ""
 msgid "Launchers"
 msgstr "啟動工具"
 
-#: src/widgets/preferences/preferences-dialog.vala:169
+#: src/widgets/preferences/preferences-dialog.vala:170
 #, fuzzy
 msgid "Default compatibility tool"
 msgstr "相容性工具"
 
-#: src/widgets/preferences/preferences-dialog.vala:170
+#: src/widgets/preferences/preferences-dialog.vala:171
 msgid "The compatibility tool games will use by default"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:196
+#: src/widgets/preferences/preferences-dialog.vala:197
 #, fuzzy
 msgid "Selected profile"
 msgstr "選擇個人檔案"
 
-#: src/widgets/preferences/preferences-dialog.vala:197
+#: src/widgets/preferences/preferences-dialog.vala:198
 msgid "Currently selected profile for Steam"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:242
+#: src/widgets/preferences/preferences-dialog.vala:243
 msgid "API Tokens"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:271
+#: src/widgets/preferences/preferences-dialog.vala:272
 msgid "Proxy URL"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:274
+#: src/widgets/preferences/preferences-dialog.vala:275
 msgid "Example: http://127.0.0.1:7890 or socks5://127.0.0.1:1080"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:286
+#: src/widgets/preferences/preferences-dialog.vala:287
 msgid "Preview features"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:287
+#: src/widgets/preferences/preferences-dialog.vala:288
 msgid "Enable experimental features for early testing"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:294
+#: src/widgets/preferences/preferences-dialog.vala:295
 #, fuzzy
 msgid "Maintenance"
 msgstr "主選單"
 
-#: src/widgets/preferences/preferences-dialog.vala:308
+#: src/widgets/preferences/preferences-dialog.vala:309
 msgid "Software Environment"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:313
+#: src/widgets/preferences/preferences-dialog.vala:314
 #: src/widgets/preferences/preferences-theme-row.vala:18
 msgid "SteamOS"
 msgstr "SteamOS"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:98
 msgid "Yes"
 msgstr "是"
 
-#: src/widgets/preferences/preferences-dialog.vala:314
-#: src/widgets/preferences/preferences-dialog.vala:319
-#: src/widgets/preferences/preferences-dialog.vala:346
-#: src/widgets/preferences/preferences-dialog.vala:351
-#: src/widgets/preferences/preferences-dialog.vala:356
-#: src/widgets/preferences/preferences-dialog.vala:361
-#: src/widgets/preferences/preferences-dialog.vala:366
-#: src/widgets/preferences/preferences-dialog.vala:371
-#: src/widgets/preferences/preferences-dialog.vala:376
+#: src/widgets/preferences/preferences-dialog.vala:315
+#: src/widgets/preferences/preferences-dialog.vala:320
+#: src/widgets/preferences/preferences-dialog.vala:347
+#: src/widgets/preferences/preferences-dialog.vala:352
+#: src/widgets/preferences/preferences-dialog.vala:357
+#: src/widgets/preferences/preferences-dialog.vala:362
+#: src/widgets/preferences/preferences-dialog.vala:367
+#: src/widgets/preferences/preferences-dialog.vala:372
+#: src/widgets/preferences/preferences-dialog.vala:377
 #: src/widgets/tools/tools-stl-release-row.vala:97
 msgid "No"
 msgstr "否"
 
-#: src/widgets/preferences/preferences-dialog.vala:318
+#: src/widgets/preferences/preferences-dialog.vala:319
 msgid "Flatpak"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:323
+#: src/widgets/preferences/preferences-dialog.vala:324
 msgid "Hardware"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:335
+#: src/widgets/preferences/preferences-dialog.vala:336
 msgid "HWCAPS"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:340
+#: src/widgets/preferences/preferences-dialog.vala:341
 msgid "Dependencies"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:345
+#: src/widgets/preferences/preferences-dialog.vala:346
 #, fuzzy
 msgid "Protontricks"
 msgstr "於 protontricks 中開啟"
 
-#: src/widgets/preferences/preferences-dialog.vala:350
+#: src/widgets/preferences/preferences-dialog.vala:351
 msgid "Protontricks (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:360
+#: src/widgets/preferences/preferences-dialog.vala:361
 msgid "MangoHud (Flatpak)"
 msgstr ""
 
-#: src/widgets/preferences/preferences-dialog.vala:375
+#: src/widgets/preferences/preferences-dialog.vala:376
 #, fuzzy
 msgid "Feral Gamemode"
 msgstr "Gamescope"
 
-#: src/widgets/preferences/preferences-dialog.vala:380
+#: src/widgets/preferences/preferences-dialog.vala:381
 #, fuzzy
 msgid "Detected Launchers"
 msgstr "偵測到的啟動器：\n"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #: src/widgets/tools/tools-box.vala:209
 #: src/widgets/tools/tools-group-box.vala:285
 msgid "Installed"
 msgstr "已安裝"
 
-#: src/widgets/preferences/preferences-dialog.vala:403
+#: src/widgets/preferences/preferences-dialog.vala:404
 #, fuzzy
 msgid "Not installed"
 msgstr "已安裝"
@@ -6793,12 +6806,12 @@ msgid "%d game selected"
 msgid_plural "%d games selected"
 msgstr[0] "已選取 %u 款遊戲"
 
-#: src/widgets/tools/tools-migrate-box.vala:142
+#: src/widgets/tools/tools-migrate-box.vala:144
 #, fuzzy
 msgid "Migration Failed"
 msgstr "正在解壓縮"
 
-#: src/widgets/tools/tools-migrate-box.vala:143
+#: src/widgets/tools/tools-migrate-box.vala:145
 msgid ""
 "Some games could not be migrated to the new compatibility tool. This may be "
 "due to missing permissions or file access issues."

--- a/src/models/compatibility-tool.vala
+++ b/src/models/compatibility-tool.vala
@@ -11,7 +11,13 @@ namespace ProtonPlus.Models {
     public class CompatibilityTool : Object {
         public string display_title { get; set; default = ""; }
         public string internal_title { get; set; default = ""; }
+        /* path is valid for the target launcher or a host-side command.
+         * inspection_path is the corresponding path visible to ProtonPlus. */
         public string path { get; set; default = ""; }
+        public string inspection_path { get; set; default = ""; }
+        public bool externally_managed { get; set; default = false; }
+        public bool is_available { get; set; default = true; }
+        public bool is_assignable { get; set; default = true; }
         public int sort_priority { get; set; default = 1000; }
         /* Providers may set this only when their runtime classification is
          * explicit.  Unknown deliberately does not grant variant capabilities. */
@@ -21,11 +27,15 @@ namespace ProtonPlus.Models {
             string display_title,
             string internal_title = "",
             string path = "",
-            CompatibilityToolRuntimeKind runtime_kind = CompatibilityToolRuntimeKind.UNKNOWN
+            CompatibilityToolRuntimeKind runtime_kind = CompatibilityToolRuntimeKind.UNKNOWN,
+            string inspection_path = "",
+            bool externally_managed = false
         ) {
             this.display_title = display_title;
             this.internal_title = internal_title != "" ? internal_title : display_title;
             this.path = path;
+            this.inspection_path = inspection_path != "" ? inspection_path : path;
+            this.externally_managed = externally_managed;
             this.runtime_kind = runtime_kind;
         }
     }

--- a/src/models/installed-tool-inventory.vala
+++ b/src/models/installed-tool-inventory.vala
@@ -102,7 +102,7 @@ namespace ProtonPlus.Models {
         }
 
         private void discover_entries () {
-            foreach (var directory_root in group.launcher.get_tool_directories (group)) {
+            foreach (var directory_root in group.launcher.get_managed_tool_directories (group)) {
                 Posix.Stat root_stat;
                 if (Posix.lstat (directory_root, out root_stat) != 0 ||
                     !Posix.S_ISDIR (root_stat.st_mode))

--- a/src/models/launcher.vala
+++ b/src/models/launcher.vala
@@ -361,10 +361,14 @@ namespace ProtonPlus.Models {
             return true;
         }
 
-        public virtual List<string> get_tool_directories (Group group) {
+        public virtual List<string> get_managed_tool_directories (Group group) {
             var directories = new List<string> ();
-            directories.append (this.directory + group.directory);
+            directories.append (get_primary_managed_tool_directory (group));
             return directories;
+        }
+
+        public virtual string get_primary_managed_tool_directory (Group group) {
+            return this.directory + group.directory;
         }
 
         public virtual async bool ensure_group_directory (string group_directory) {

--- a/src/models/launchers/steam.vala
+++ b/src/models/launchers/steam.vala
@@ -6,11 +6,13 @@ namespace ProtonPlus.Models.Launchers {
         public string default_compatibility_tool { get; set; }
         public HashTable<uint, string> compatibility_tool_hashtable;
         private Games.AwacyGameCatalog awacy_game_catalog;
+        private SteamCompatibilityToolDiscovery compatibility_tool_discovery;
         private uint game_library_generation;
 
         public Steam (
             Launcher.InstallationTypes installation_type,
-            Games.AwacyGameCatalog? awacy_game_catalog = null
+            Games.AwacyGameCatalog? awacy_game_catalog = null,
+            SteamCompatibilityToolDiscovery? compatibility_tool_discovery = null
         ) {
             string[] directories = null;
 
@@ -40,6 +42,8 @@ namespace ProtonPlus.Models.Launchers {
             default_compatibility_tool = "";
             compatibility_tool_hashtable = new HashTable<uint, string> (null, null);
             this.awacy_game_catalog = awacy_game_catalog ?? Games.AwacyGameCatalog.get_shared ();
+            this.compatibility_tool_discovery = compatibility_tool_discovery
+                ?? new SteamCompatibilityToolDiscovery (installation_type, Globals.IS_FLATPAK);
         }
 
         public override SteamRestartTarget? get_steam_restart_target () {
@@ -91,27 +95,30 @@ namespace ProtonPlus.Models.Launchers {
                 compatibility_tool_hashtable.set (appid, compatibility_tool);
         }
 
-        public override List<string> get_tool_directories (Group group) {
+        public override List<string> get_managed_tool_directories (Group group) {
             var directories = new List<string> ();
-            directories.append (this.directory + group.directory);
-            directories.append ("/usr/share/steam" + group.directory);
-
-            if (installation_type != Launcher.InstallationTypes.FLATPAK) {
-                return directories;
-            }
-
-            foreach (var extension_root in get_flatpak_steam_extension_roots ()) {
-                if (is_tool_root (extension_root) && !path_exists_in_list (directories, extension_root)) {
-                    directories.append (extension_root);
-                }
-
-                var extension_share_tools = "%s/share/steam%s".printf (extension_root, group.directory);
-                if (FileUtils.test (extension_share_tools, FileTest.IS_DIR) && !path_exists_in_list (directories, extension_share_tools)) {
-                    directories.append (extension_share_tools);
-                }
-            }
-
+            directories.append (get_primary_managed_tool_directory (group));
             return directories;
+        }
+
+        public override string get_primary_managed_tool_directory (Group group) {
+            return get_managed_compatibility_tools_root ();
+        }
+
+        private string get_managed_compatibility_tools_root () {
+            if (installation_type == Launcher.InstallationTypes.SYSTEM
+                && Filename.canonicalize (directory, null) == "/usr/share/steam") {
+                var host_data_home = Environment.get_variable ("HOST_XDG_DATA_HOME");
+                if (host_data_home == null || host_data_home == "") {
+                    host_data_home = Globals.IS_FLATPAK
+                        ? Path.build_filename (Environment.get_home_dir (), ".local", "share")
+                        : Environment.get_user_data_dir ();
+                }
+                return Path.build_filename (
+                    (!) host_data_home, "Steam", "compatibilitytools.d"
+                );
+            }
+            return Path.build_filename (directory, "compatibilitytools.d");
         }
 
         public SteamProfile? get_steam_profile_by_id (string steam_id) {
@@ -119,121 +126,6 @@ namespace ProtonPlus.Models.Launchers {
                 if (profile.steam_id == steam_id)
                     return profile;
             return null;
-        }
-
-        private List<string> get_flatpak_steam_extension_roots () {
-            var extension_roots = new List<string> ();
-
-            var runtime_roots = new string[] {
-                "%s/.local/share/flatpak/runtime".printf (Environment.get_home_dir ()),
-                "/var/lib/flatpak/runtime"
-            };
-
-            foreach (var runtime_root in runtime_roots) {
-                if (!FileUtils.test (runtime_root, FileTest.IS_DIR)) {
-                    continue;
-                }
-
-                try {
-                    var runtime_root_file = File.new_for_path (runtime_root);
-                    var runtime_enumerator = runtime_root_file.enumerate_children ("standard::*", FileQueryInfoFlags.NONE, null);
-                    if (runtime_enumerator == null) {
-                        continue;
-                    }
-
-                    FileInfo? runtime_info;
-                    while ((runtime_info = runtime_enumerator.next_file ()) != null) {
-                        if (runtime_info.get_file_type () != FileType.DIRECTORY) {
-                            continue;
-                        }
-
-                        var extension_id = runtime_info.get_name ();
-                        if (!(extension_id.has_prefix ("com.valvesoftware.Steam.CompatibilityTool.") ||
-                            extension_id.has_prefix ("com.valvesoftware.Steam.Utility."))) {
-                            continue;
-                        }
-
-                        var extension_root = "%s/%s".printf (runtime_root, extension_id);
-                        var extension_root_file = File.new_for_path (extension_root);
-                        var arch_enumerator = extension_root_file.enumerate_children ("standard::*", FileQueryInfoFlags.NONE, null);
-                        if (arch_enumerator == null) {
-                            continue;
-                        }
-
-                        FileInfo? arch_info;
-                        while ((arch_info = arch_enumerator.next_file ()) != null) {
-                            if (arch_info.get_file_type () != FileType.DIRECTORY) {
-                                continue;
-                            }
-
-                            var arch_root = "%s/%s".printf (extension_root, arch_info.get_name ());
-                            var arch_root_file = File.new_for_path (arch_root);
-                            var branch_enumerator = arch_root_file.enumerate_children ("standard::*", FileQueryInfoFlags.NONE, null);
-                            if (branch_enumerator == null) {
-                                continue;
-                            }
-
-                            FileInfo? branch_info;
-                            while ((branch_info = branch_enumerator.next_file ()) != null) {
-                                if (branch_info.get_file_type () != FileType.DIRECTORY) {
-                                    continue;
-                                }
-
-                                var branch_root = "%s/%s".printf (arch_root, branch_info.get_name ());
-                                var active_files = "%s/active/files".printf (branch_root);
-                                if (FileUtils.test (active_files, FileTest.IS_DIR) && !path_exists_in_list (extension_roots, active_files)) {
-                                    extension_roots.append (active_files);
-                                }
-
-                                var branch_root_file = File.new_for_path (branch_root);
-                                var deploy_enumerator = branch_root_file.enumerate_children ("standard::*", FileQueryInfoFlags.NONE, null);
-                                if (deploy_enumerator == null) {
-                                    continue;
-                                }
-
-                                FileInfo? deploy_info;
-                                while ((deploy_info = deploy_enumerator.next_file ()) != null) {
-                                    if (deploy_info.get_file_type () != FileType.DIRECTORY) {
-                                        continue;
-                                    }
-
-                                    var deploy_name = deploy_info.get_name ();
-                                    if (deploy_name == "active") {
-                                        continue;
-                                    }
-
-                                    var deploy_files = "%s/%s/files".printf (branch_root, deploy_name);
-                                    if (!FileUtils.test (deploy_files, FileTest.IS_DIR)) {
-                                        continue;
-                                    }
-
-                                    if (!path_exists_in_list (extension_roots, deploy_files)) {
-                                        extension_roots.append (deploy_files);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } catch (Error e) {
-                    warning (e.message);
-                }
-            }
-
-            return extension_roots;
-        }
-
-        private bool path_exists_in_list (List<string> paths, string target_path) {
-            foreach (var path in paths) {
-                if (path == target_path) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private bool is_tool_root (string path) {
-            return FileUtils.test ("%s/compatibilitytool.vdf".printf (path), FileTest.IS_REGULAR);
         }
 
         public async void switch_profile (SteamProfile profile) {
@@ -287,20 +179,14 @@ namespace ProtonPlus.Models.Launchers {
             games = new List<Game> ();
 
             compatibility_tools.clear ();
+            compatibility_tool_discovery.clear ();
 
-            var proton_regex = /(?i)^Proton\s*\d+(?:\.\d+)*/;
             var name_regex = /\"name\"\s+\"([^\"]+)\"/;
             var dir_regex = /\"installdir\"\s+\"([^\"]+)\"/;
 
             var excluded_appids = new Gee.HashSet<string> ();
             excluded_appids.add_all_array (new string[] {
                 "2230260", "1826330", "1161040", "1070560", "1628350", "228980", "4183110", "3086180", "250820"
-            });
-
-            var native_compatibility_tool_appids = new Gee.HashSet<string> ();
-            native_compatibility_tool_appids.add_all_array (new string[] {
-                "2180100", "1493710", "3658110", "4628710", "2348590", "2805730", "1887720",
-                "1580130", "1420170", "1245040", "1054830", "1113280", "858280", "961940"
             });
 
             var compatibility_tool_hashtable_loaded = yield load_compatibility_tool_hashtable ();
@@ -361,15 +247,15 @@ namespace ProtonPlus.Models.Launchers {
                     continue;
                     current_installdir = dir_match.fetch (1);
 
-                    if (is_steam_linux_runtime (current_name)) {
-                        var compatibility_tool = new CompatibilityTool (
-                            current_name,
-                            current_name.down ().split (".", 2)[0].replace (" ", "_"),
+                    string steam_tool_internal_title;
+                    CompatibilityToolRuntimeKind steam_tool_runtime_kind;
+                    if (SteamCompatibilityToolDiscovery.try_get_steam_library_tool_identity (
+                            id, out steam_tool_internal_title, out steam_tool_runtime_kind
+                        )) {
+                        compatibility_tool_discovery.add_steam_library_app (
                             "%s/common/%s".printf (current_steamapps_path, current_installdir),
-                            CompatibilityToolRuntimeKind.NATIVE
+                            id, steam_tool_internal_title, current_name, steam_tool_runtime_kind
                         );
-                        compatibility_tool.sort_priority = get_compatibility_tool_sort_priority (compatibility_tool);
-                        compatibility_tools.add (compatibility_tool);
                         continue;
                     }
 
@@ -382,19 +268,10 @@ namespace ProtonPlus.Models.Launchers {
                         Path.build_filename (compatibility_tool_path, "proton"),
                         FileTest.IS_REGULAR
                     );
-                    var is_named_proton = proton_regex.match (current_name) || current_name == "Proton Hotfix";
 
-                    if (has_proton_launcher || is_named_proton || native_compatibility_tool_appids.contains (current_appid)) {
-                        var compatibility_tool = new CompatibilityTool (
-                            current_name,
-                            current_name.down ().split (".", 2)[0].replace (" ", "_"),
-                            compatibility_tool_path,
-                            has_proton_launcher || is_named_proton
-                                ? CompatibilityToolRuntimeKind.PROTON
-                                : CompatibilityToolRuntimeKind.NATIVE
-                        );
-                        compatibility_tool.sort_priority = get_compatibility_tool_sort_priority (compatibility_tool);
-                        compatibility_tools.add (compatibility_tool);
+                    if (has_proton_launcher || is_steam_linux_runtime (current_name)) {
+                        debug ("Ignoring unrecognized Steam compatibility-tool app %s (%s)",
+                            current_appid, current_name);
                         continue;
                     }
 
@@ -412,47 +289,7 @@ namespace ProtonPlus.Models.Launchers {
                 }
             }
 
-            try {
-                foreach (var group in groups) {
-                    var tool_directory = "%s%s".printf (directory, group.directory);
-                    if (!FileUtils.test (tool_directory, FileTest.IS_DIR)) {
-                        continue;
-                    }
-
-                    File directory = File.new_for_path (tool_directory);
-                    FileEnumerator? enumerator = directory.enumerate_children ("standard::*", FileQueryInfoFlags.NONE, null);
-
-                    if (enumerator != null) {
-                        FileInfo? file_info;
-                        while ((file_info = enumerator.next_file ()) != null) {
-                            if (file_info.get_file_type () != FileType.DIRECTORY)
-                            continue;
-
-                            var file_name = file_info.get_name ();
-                            if (file_name == null) {
-                                continue;
-                            }
-
-                            if (file_name.contains ("wine-proton-exp") || file_name == "LegacyRuntime") {
-                                continue;
-                            }
-
-                            var file_path = "%s/%s".printf (directory.get_path (), file_name);
-                            var compatibility_tool = Utils.VDF.CompatibilityToolLoader.from_path (file_path);
-                            compatibility_tool.sort_priority = get_compatibility_tool_sort_priority (compatibility_tool);
-                            compatibility_tools.add (compatibility_tool);
-                        }
-                    }
-                }
-            } catch (Error e) {
-                warning (e.message);
-            }
-
-            if (installation_type == Launcher.InstallationTypes.FLATPAK) {
-                add_flatpak_extension_tools_to_compatibility_tools ();
-            }
-
-            sort_compatibility_tools ();
+            load_discovered_compatibility_tools ();
 
             schedule_awacy_enrichment (current_generation);
 
@@ -484,37 +321,38 @@ namespace ProtonPlus.Models.Launchers {
             }
         }
 
-        private void add_flatpak_extension_tools_to_compatibility_tools () {
-            foreach (var extension_root in get_flatpak_steam_extension_roots ()) {
-                if (is_tool_root (extension_root)) {
-                    var compatibility_tool = Utils.VDF.CompatibilityToolLoader.from_path (extension_root);
-                    add_compatibility_tool_if_missing (compatibility_tool);
-                }
+        public void refresh_compatibility_tools () {
+            compatibility_tool_discovery.clear ();
+            load_discovered_compatibility_tools ();
+        }
 
-                var extension_tools_root = "%s/share/steam/compatibilitytools.d".printf (extension_root);
-                if (!FileUtils.test (extension_tools_root, FileTest.IS_DIR)) {
+        private void load_discovered_compatibility_tools () {
+            compatibility_tool_discovery.discover_launcher_roots (
+                get_managed_compatibility_tools_root ()
+            );
+            compatibility_tools.clear ();
+            foreach (var compatibility_tool in compatibility_tool_discovery.get_snapshot ()) {
+                compatibility_tool.sort_priority = get_compatibility_tool_sort_priority (compatibility_tool);
+                compatibility_tools.add (compatibility_tool);
+            }
+            add_unavailable_mappings ();
+            sort_compatibility_tools ();
+        }
+
+        private void add_unavailable_mappings () {
+            if (compatibility_tool_hashtable == null)
+                return;
+            foreach (var internal_title in compatibility_tool_hashtable.get_values ()) {
+                if (internal_title == null || internal_title == "Default"
+                    || find_compatibility_tool (internal_title) != null)
                     continue;
-                }
-
-                try {
-                    var extension_tools_directory = File.new_for_path (extension_tools_root);
-                    var enumerator = extension_tools_directory.enumerate_children ("standard::*", FileQueryInfoFlags.NONE, null);
-                    if (enumerator == null) {
-                        continue;
-                    }
-
-                    FileInfo? file_info;
-                    while ((file_info = enumerator.next_file ()) != null) {
-                        if (file_info.get_file_type () != FileType.DIRECTORY) {
-                            continue;
-                        }
-
-                        var tool_path = "%s/%s".printf (extension_tools_root, file_info.get_name ());
-                        add_compatibility_tool_if_missing (Utils.VDF.CompatibilityToolLoader.from_path (tool_path));
-                    }
-                } catch (Error e) {
-                    warning (e.message);
-                }
+                var unavailable = new CompatibilityTool (
+                    _("%s (Unavailable)").printf (internal_title), internal_title
+                );
+                unavailable.is_available = false;
+                unavailable.is_assignable = false;
+                unavailable.sort_priority = 900;
+                compatibility_tools.add (unavailable);
             }
         }
 
@@ -542,6 +380,33 @@ namespace ProtonPlus.Models.Launchers {
             return null;
         }
 
+        public Gee.List<CompatibilityTool> get_assignable_compatibility_tools () {
+            var tools = new Gee.ArrayList<CompatibilityTool> ();
+            foreach (var tool in compatibility_tools) {
+                if (tool.is_assignable && tool.is_available)
+                    tools.add (tool);
+            }
+            return tools;
+        }
+
+        public bool can_assign_compatibility_tool (string internal_title) {
+            if (internal_title == "Default")
+                return true;
+            var tool = find_compatibility_tool (internal_title);
+            if (tool == null || !((!) tool).is_assignable || !((!) tool).is_available)
+                return false;
+            return !((!) tool).externally_managed
+                || compatibility_tool_discovery.remains_available ((!) tool);
+        }
+
+        public bool external_compatibility_tool_remains_available (string internal_title) {
+            var tool = find_compatibility_tool (internal_title);
+            if (tool == null || !((!) tool).externally_managed)
+                return true;
+            return ((!) tool).is_assignable && ((!) tool).is_available
+                && compatibility_tool_discovery.remains_available ((!) tool);
+        }
+
         /* Steam persists "Default" as an alias for CompatToolMapping app ID 0.
          * Resolve that alias at the launcher boundary so consumers which need
          * a concrete installation (feature probes and future compatibility
@@ -564,12 +429,12 @@ namespace ProtonPlus.Models.Launchers {
             if (tool == null || ((!) tool).path.strip () == "")
                 return null;
 
-            var proton_path = Path.build_filename (((!) tool).path, "proton");
-            if (!FileUtils.test (proton_path, FileTest.IS_REGULAR)
-                || !FileUtils.test (proton_path, FileTest.IS_EXECUTABLE))
+            var inspection_proton_path = Path.build_filename (((!) tool).inspection_path, "proton");
+            if (!FileUtils.test (inspection_proton_path, FileTest.IS_REGULAR)
+                || !FileUtils.test (inspection_proton_path, FileTest.IS_EXECUTABLE))
                 return null;
 
-            return proton_path;
+            return Path.build_filename (((!) tool).path, "proton");
         }
 
         public override void register_compatibility_tool_from_path (string tool_path) {

--- a/src/models/meson.build
+++ b/src/models/meson.build
@@ -4,6 +4,7 @@ sources += files(
     'variant-selector.vala',
     'group.vala',
     'compatibility-tool.vala',
+    'steam-compatibility-tool-discovery.vala',
     'installed-tool-inventory.vala',
     'steam-profile.vala',
     'steam-restart-target.vala',

--- a/src/models/steam-compatibility-tool-discovery.vala
+++ b/src/models/steam-compatibility-tool-discovery.vala
@@ -1,0 +1,323 @@
+namespace ProtonPlus.Models {
+    /* Discovers tools Steam may select without granting ProtonPlus ownership
+     * of their files or installation lifecycle. Roots are constructor-
+     * injectable so tests never inspect real Steam, /usr, or Flatpak data. */
+    public class SteamCompatibilityToolDiscovery : Object {
+        private Launcher.InstallationTypes installation_type;
+        private string system_root;
+        private string system_inspection_root;
+        private string[] flatpak_runtime_roots;
+        private Gee.HashMap<string, CompatibilityTool> tools_by_internal_title;
+        private Gee.HashMap<string, int> precedence_by_internal_title;
+        private Gee.HashMap<string, string> internal_title_by_logical_location;
+        private Gee.HashMap<string, uint> steam_appid_by_internal_title;
+
+        public SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes installation_type,
+            bool running_in_flatpak = false,
+            string system_root = "/usr/share/steam/compatibilitytools.d",
+            string system_inspection_root = "",
+            string[]? flatpak_runtime_roots = null
+        ) {
+            this.installation_type = installation_type;
+            this.system_root = system_root;
+            this.system_inspection_root = system_inspection_root != ""
+                ? system_inspection_root
+                : running_in_flatpak
+                    ? "/run/host/usr/share/steam/compatibilitytools.d"
+                    : system_root;
+            if (flatpak_runtime_roots != null) {
+                this.flatpak_runtime_roots = (!) flatpak_runtime_roots;
+            } else {
+                this.flatpak_runtime_roots = {
+                    Path.build_filename (Environment.get_home_dir (), ".local", "share", "flatpak", "runtime"),
+                    "/var/lib/flatpak/runtime"
+                };
+            }
+            tools_by_internal_title = new Gee.HashMap<string, CompatibilityTool> ();
+            precedence_by_internal_title = new Gee.HashMap<string, int> ();
+            internal_title_by_logical_location = new Gee.HashMap<string, string> ();
+            steam_appid_by_internal_title = new Gee.HashMap<string, uint> ();
+        }
+
+        public void clear () {
+            tools_by_internal_title.clear ();
+            precedence_by_internal_title.clear ();
+            internal_title_by_logical_location.clear ();
+            steam_appid_by_internal_title.clear ();
+        }
+
+        public void add_steam_library_app (
+            string path,
+            uint appid,
+            string internal_title,
+            string display_title,
+            CompatibilityToolRuntimeKind runtime_kind
+        ) {
+            var tool = new CompatibilityTool (
+                display_title, internal_title, path, runtime_kind, path, true
+            );
+            if (!steam_library_tool_is_usable (tool, appid))
+                return;
+            add_tool (tool, 300, appid);
+        }
+
+        public static bool try_get_steam_library_tool_identity (
+            uint appid,
+            out string internal_title,
+            out CompatibilityToolRuntimeKind runtime_kind
+        ) {
+            runtime_kind = CompatibilityToolRuntimeKind.PROTON;
+            switch (appid) {
+            case 2180100: internal_title = "proton_hotfix"; return true;
+            case 1493710: internal_title = "proton_experimental"; return true;
+            case 3658110: internal_title = "proton_10"; return true;
+            case 4628710: internal_title = "proton_11"; return true;
+            case 2348590: internal_title = "proton_8"; return true;
+            case 2805730: internal_title = "proton_9"; return true;
+            case 1887720: internal_title = "proton_7"; return true;
+            case 1580130: internal_title = "proton_63"; return true;
+            case 1420170: internal_title = "proton_513"; return true;
+            case 1245040: internal_title = "proton_5"; return true;
+            case 1054830: internal_title = "proton_411"; return true;
+            case 1113280: internal_title = "proton_42"; return true;
+            case 961940: internal_title = "proton_316"; return true;
+            case 858280: internal_title = "proton_37"; return true;
+            case 1070560:
+                internal_title = "steamlinuxruntime";
+                runtime_kind = CompatibilityToolRuntimeKind.NATIVE;
+                return true;
+            case 1391110:
+                internal_title = "steamlinuxruntime_soldier";
+                runtime_kind = CompatibilityToolRuntimeKind.NATIVE;
+                return true;
+            case 1628350:
+                internal_title = "steamlinuxruntime_sniper";
+                runtime_kind = CompatibilityToolRuntimeKind.NATIVE;
+                return true;
+            case 4183110:
+                internal_title = "steamlinuxruntime_4";
+                runtime_kind = CompatibilityToolRuntimeKind.NATIVE;
+                return true;
+            default:
+                internal_title = "";
+                runtime_kind = CompatibilityToolRuntimeKind.UNKNOWN;
+                return false;
+            }
+        }
+
+        public void discover_launcher_roots (string managed_tools_root) {
+            discover_children (managed_tools_root, managed_tools_root, false, 100);
+
+            if (installation_type == Launcher.InstallationTypes.SYSTEM) {
+                discover_children (system_root, system_inspection_root, true, 200);
+            } else if (installation_type == Launcher.InstallationTypes.FLATPAK) {
+                discover_flatpak_extensions ();
+            }
+        }
+
+        public Gee.List<CompatibilityTool> get_snapshot () {
+            var snapshot = new Gee.ArrayList<CompatibilityTool> ();
+            foreach (var tool in tools_by_internal_title.values)
+                snapshot.add (tool);
+            return snapshot;
+        }
+
+        public bool remains_available (CompatibilityTool tool) {
+            if (!tool.is_available || tool.inspection_path.strip () == "")
+                return false;
+            var steam_appid = steam_appid_by_internal_title.get (tool.internal_title);
+            if (steam_appid != 0)
+                return steam_library_tool_is_usable (tool, steam_appid);
+            var current = ProtonPlus.Utils.VDF.CompatibilityToolLoader.try_from_paths (
+                tool.path, tool.inspection_path, tool.externally_managed
+            );
+            return current != null && ((!) current).internal_title == tool.internal_title;
+        }
+
+        private void discover_flatpak_extensions () {
+            foreach (var runtime_root in flatpak_runtime_roots) {
+                foreach_directory_child (runtime_root, (extension_id, extension_root) => {
+                    if (!(extension_id.has_prefix ("com.valvesoftware.Steam.CompatibilityTool.")
+                        || extension_id.has_prefix ("com.valvesoftware.Steam.Utility.")))
+                        return;
+                    foreach_directory_child (extension_root, (arch, arch_root) => {
+                        foreach_directory_child (arch_root, (branch, branch_root) => {
+                            var active_deployment = get_active_deployment_name (branch_root);
+                            foreach_directory_child (branch_root, (deployment, deployment_root) => {
+                                if (deployment == "active")
+                                    return;
+                                var precedence = deployment == active_deployment ? 150 : 250;
+                                var files_root = Path.build_filename (deployment_root, "files");
+                                if (!is_directory_without_following (files_root))
+                                    return;
+                                add_tool_path (files_root, files_root, true, precedence);
+                                var tools_root = Path.build_filename (
+                                    files_root, "share", "steam", "compatibilitytools.d"
+                                );
+                                discover_children (tools_root, tools_root, true, precedence);
+                            });
+                        });
+                    });
+                });
+            }
+        }
+
+        private delegate void DirectoryChildCallback (string name, string path);
+
+        private void foreach_directory_child (string root, DirectoryChildCallback callback) {
+            if (!is_directory_without_following (root))
+                return;
+            FileEnumerator? enumerator = null;
+            try {
+                var names = new Gee.ArrayList<string> ();
+                enumerator = File.new_for_path (root).enumerate_children (
+                    "standard::name,standard::type", FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null
+                );
+                FileInfo? info;
+                while ((info = enumerator.next_file ()) != null) {
+                    if (info.get_file_type () != FileType.DIRECTORY)
+                        continue;
+                    var child = Path.build_filename (root, info.get_name ());
+                    if (!is_directory_without_following (child))
+                        continue;
+                    names.add (info.get_name ());
+                }
+                names.sort ((a, b) => strcmp (a, b));
+                foreach (var name in names)
+                    callback (name, Path.build_filename (root, name));
+            } catch (Error error) {
+                debug ("Compatibility-tool root %s is unavailable: %s", root, error.message);
+            } finally {
+                if (enumerator != null) {
+                    try { ((!) enumerator).close (null); } catch (Error error) {}
+                }
+            }
+        }
+
+        /* Flatpak's active entry is a symlink. Read only its target name, then
+         * inspect the independently lstat-validated deployment directory; do
+         * not enumerate through or resolve the symlink itself. */
+        private string get_active_deployment_name (string branch_root) {
+            try {
+                var info = File.new_for_path (Path.build_filename (branch_root, "active")).query_info (
+                    "standard::type,standard::symlink-target",
+                    FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null
+                );
+                if (info.get_file_type () != FileType.SYMBOLIC_LINK)
+                    return "";
+                var target = info.get_symlink_target ();
+                if (target == null || target == "" || Path.is_absolute ((!) target)
+                    || ((!) target).contains ("/") || (!) target == "." || (!) target == "..")
+                    return "";
+                return (!) target;
+            } catch (Error error) {
+                return "";
+            }
+        }
+
+        private void discover_children (
+            string path_root,
+            string inspection_root,
+            bool externally_managed,
+            int precedence
+        ) {
+            foreach_directory_child (inspection_root, (name, inspection_path) => {
+                add_tool_path (
+                    Path.build_filename (path_root, name), inspection_path,
+                    externally_managed, precedence
+                );
+            });
+        }
+
+        private void add_tool_path (
+            string path,
+            string inspection_path,
+            bool externally_managed,
+            int precedence,
+            CompatibilityToolRuntimeKind runtime_kind = CompatibilityToolRuntimeKind.UNKNOWN
+        ) {
+            var tool = ProtonPlus.Utils.VDF.CompatibilityToolLoader.try_from_paths (
+                path, inspection_path, externally_managed
+            );
+            if (tool == null)
+                return;
+            if (runtime_kind != CompatibilityToolRuntimeKind.UNKNOWN)
+                ((!) tool).runtime_kind = runtime_kind;
+
+            add_tool ((!) tool, precedence);
+        }
+
+        private void add_tool (CompatibilityTool tool, int precedence, uint steam_appid = 0) {
+            var logical_location = normalize_logical_location (tool.path);
+            var location_internal_title = internal_title_by_logical_location.get (logical_location);
+            if (location_internal_title != null) {
+                var location_precedence = precedence_by_internal_title.get ((!) location_internal_title);
+                if (location_precedence <= precedence)
+                    return;
+                remove_tool ((!) location_internal_title);
+            }
+            var existing_precedence = precedence_by_internal_title.get (tool.internal_title);
+            if (tools_by_internal_title.has_key (tool.internal_title)
+                && existing_precedence <= precedence)
+                return;
+
+            if (tools_by_internal_title.has_key (tool.internal_title))
+                remove_tool (tool.internal_title);
+            tools_by_internal_title.set (tool.internal_title, tool);
+            precedence_by_internal_title.set (tool.internal_title, precedence);
+            internal_title_by_logical_location.set (logical_location, tool.internal_title);
+            if (steam_appid != 0)
+                steam_appid_by_internal_title.set (tool.internal_title, steam_appid);
+        }
+
+        private void remove_tool (string internal_title) {
+            var existing = tools_by_internal_title.get (internal_title);
+            if (existing != null)
+                internal_title_by_logical_location.unset (
+                    normalize_logical_location (((!) existing).path)
+                );
+            tools_by_internal_title.unset (internal_title);
+            precedence_by_internal_title.unset (internal_title);
+            steam_appid_by_internal_title.unset (internal_title);
+        }
+
+        private bool steam_library_tool_is_usable (CompatibilityTool tool, uint appid) {
+            string expected_internal_title;
+            CompatibilityToolRuntimeKind expected_runtime_kind;
+            if (!try_get_steam_library_tool_identity (
+                    appid, out expected_internal_title, out expected_runtime_kind
+                )
+                || expected_internal_title != tool.internal_title
+                || expected_runtime_kind != tool.runtime_kind
+                || !is_directory_without_following (tool.inspection_path))
+                return false;
+
+            Posix.Stat manifest_stat;
+            if (Posix.lstat (
+                    Path.build_filename (tool.inspection_path, "toolmanifest.vdf"),
+                    out manifest_stat
+                ) != 0 || !Posix.S_ISREG (manifest_stat.st_mode))
+                return false;
+            if (expected_runtime_kind != CompatibilityToolRuntimeKind.PROTON)
+                return true;
+
+            Posix.Stat proton_stat;
+            return Posix.lstat (
+                Path.build_filename (tool.inspection_path, "proton"), out proton_stat
+            ) == 0 && Posix.S_ISREG (proton_stat.st_mode);
+        }
+
+        private string normalize_logical_location (string path) {
+            var canonical = Filename.canonicalize (path, null);
+            if (canonical.has_prefix ("/run/host/"))
+                return canonical.substring ("/run/host".length);
+            return canonical;
+        }
+
+        private bool is_directory_without_following (string path) {
+            Posix.Stat stat;
+            return Posix.lstat (path, out stat) == 0 && Posix.S_ISDIR (stat.st_mode);
+        }
+    }
+}

--- a/src/services/install-job.vala
+++ b/src/services/install-job.vala
@@ -346,9 +346,8 @@ namespace ProtonPlus.Services {
             var provider_tool = tool as Models.Tools.ProviderTool;
             if (provider_tool == null)
                 return;
-            install_location = "%s%s/%s".printf (
-                tool.group.launcher.directory,
-                tool.group.directory,
+            install_location = Path.build_filename (
+                tool.group.launcher.get_primary_managed_tool_directory (tool.group),
                 effective_directory_name (provider_tool)
             );
         }

--- a/src/services/standard-archive-workflow.vala
+++ b/src/services/standard-archive-workflow.vala
@@ -120,8 +120,9 @@ namespace ProtonPlus.Services {
             var directory_valid = provider_tool != null && job.effective_directory_name_for_state () != "";
             var installed = job.install_location != "" && FileUtils.test (job.install_location, FileTest.IS_DIR);
             if (job.mode == InstallJob.Mode.LATEST && provider_tool != null) {
-                var backup = "%s%s/%s Latest Backup".printf (
-                    job.tool.group.launcher.directory, job.tool.group.directory, job.tool.title
+                var backup = Path.build_filename (
+                    job.tool.group.launcher.get_primary_managed_tool_directory (job.tool.group),
+                    "%s Latest Backup".printf (job.tool.title)
                 );
                 installed = installed || FileUtils.test (backup, FileTest.IS_DIR);
             }
@@ -141,8 +142,9 @@ namespace ProtonPlus.Services {
             InstallationOperationCoordinator coordinator,
             string? installation_location = null
         ) {
-            var directory = installation_location ?? "%s%s/%s Latest".printf (
-                runner.group.launcher.directory, runner.group.directory, runner.title
+            var directory = installation_location ?? Path.build_filename (
+                runner.group.launcher.get_primary_managed_tool_directory (runner.group),
+                "%s Latest".printf (runner.title)
             );
             if (!FileUtils.test (directory, FileTest.IS_DIR))
                 return ReturnCode.RUNNER_NOT_INSTALLED;
@@ -173,8 +175,9 @@ namespace ProtonPlus.Services {
         // installing.  Restore it only when no primary exists; a coexisting
         // backup remains recovery state until another path proves it obsolete.
         internal async ReturnCode restore_legacy_latest_backup (Models.Tools.ProviderTool runner) {
-            var directory = "%s%s/%s Latest".printf (
-                runner.group.launcher.directory, runner.group.directory, runner.title
+            var directory = Path.build_filename (
+                runner.group.launcher.get_primary_managed_tool_directory (runner.group),
+                "%s Latest".printf (runner.title)
             );
             var backup = "%s Backup".printf (directory);
             if (FileUtils.test (directory, FileTest.EXISTS))

--- a/src/services/steam-configuration-service.vala
+++ b/src/services/steam-configuration-service.vala
@@ -211,6 +211,11 @@ namespace ProtonPlus.Services {
         }
 
         private SteamConfigurationMutation change_compatibility_mapping (Launchers.Steam steam, uint appid, string value, SteamChangeKind kind) {
+            if (!steam.external_compatibility_tool_remains_available (value))
+                return new SteamConfigurationMutation (
+                    SteamConfigurationMutationResult.FAILED,
+                    "The externally managed compatibility tool is no longer available."
+                );
             var target = steam.get_steam_restart_target ();
             if (target == null) return new SteamConfigurationMutation (SteamConfigurationMutationResult.FAILED, "No Steam target.");
             var path = Path.build_filename (steam.directory, "config", "config.vdf");

--- a/src/services/steam-tinker-launch-context.vala
+++ b/src/services/steam-tinker-launch-context.vala
@@ -21,7 +21,7 @@ namespace ProtonPlus.Services {
 
         internal SteamTinkerLaunchContext (Models.Tool tool, string? home_override = null) {
             home_location = home_override ?? Environment.get_home_dir ();
-            compat_location = tool.group.launcher.directory + tool.group.directory;
+            compat_location = tool.group.launcher.get_primary_managed_tool_directory (tool.group);
             if (Globals.IS_STEAM_OS) {
                 base_location = "%s/stl/prefix".printf (home_location);
                 manual_remove_location = "%s/stl".printf (home_location);

--- a/src/utils/vdf/compatibility-tool-loader.vala
+++ b/src/utils/vdf/compatibility-tool-loader.vala
@@ -3,7 +3,63 @@ namespace ProtonPlus.Utils.VDF {
     // launcher discovery.  Keep this parsing behavior aligned with the
     // historical Simple.from_path implementation.
     public class CompatibilityToolLoader : Object {
+        public static Models.CompatibilityTool? try_from_paths (
+            string path,
+            string inspection_path,
+            bool externally_managed = false
+        ) {
+            Posix.Stat root_stat;
+            if (Posix.lstat (inspection_path, out root_stat) != 0 || !Posix.S_ISDIR (root_stat.st_mode))
+                return null;
+
+            var manifest_path = Path.build_filename (inspection_path, "compatibilitytool.vdf");
+            Posix.Stat manifest_stat;
+            if (Posix.lstat (manifest_path, out manifest_stat) != 0 || !Posix.S_ISREG (manifest_stat.st_mode))
+                return null;
+
+            var document = VdfParser.parse_document (Filesystem.get_file_content (manifest_path));
+            if (document == null)
+                return null;
+            var compatibility_tools = find_compat_tools ((!) document);
+            if (compatibility_tools == null || compatibility_tools.children.size == 0)
+                return null;
+
+            var definition = compatibility_tools.children[0];
+            var internal_title = definition.key.strip ();
+            if (!valid_internal_title (internal_title))
+                return null;
+
+            var display_name = definition.get_child ("display_name");
+            var display_title = display_name?.value ?? internal_title;
+            if (display_title.strip () == "")
+                display_title = internal_title;
+
+            var tool = new Models.CompatibilityTool (
+                display_title, internal_title, path,
+                Models.CompatibilityToolRuntimeKind.UNKNOWN,
+                inspection_path, externally_managed
+            );
+            Posix.Stat proton_stat;
+            if (Posix.lstat (Path.build_filename (inspection_path, "proton"), out proton_stat) == 0
+                && Posix.S_ISREG (proton_stat.st_mode))
+                tool.runtime_kind = Models.CompatibilityToolRuntimeKind.PROTON;
+            return tool;
+        }
+
+        private static VdfEntry? find_compat_tools (VdfDocument document) {
+            var compatibility_tools = document.root.get_child ("compat_tools");
+            if (compatibility_tools != null)
+                return compatibility_tools;
+
+            var manifest = document.root.get_child ("compatibilitytools");
+            return manifest?.get_child ("compat_tools");
+        }
+
         public static Models.CompatibilityTool from_path (string path) {
+            var parsed = try_from_paths (path, path);
+            if (parsed != null)
+                return (!) parsed;
+
             var fallback_title = Path.get_basename (path);
             var tool = new Models.CompatibilityTool (fallback_title, fallback_title, path);
             /* A tool-owned Proton launcher is an explicit runtime fact.  This
@@ -42,6 +98,17 @@ namespace ProtonPlus.Utils.VDF {
             }
 
             return tool;
+        }
+
+        private static bool valid_internal_title (string value) {
+            if (value == "" || value == "." || value == ".."
+                || value.contains ("/") || value.contains ("\\"))
+                return false;
+            for (var index = 0; index < value.length; index++) {
+                if (value[index] < 0x20 || value[index] == 0x7f)
+                    return false;
+            }
+            return true;
         }
     }
 }

--- a/src/widgets/games/games-box.vala
+++ b/src/widgets/games/games-box.vala
@@ -397,8 +397,14 @@ namespace ProtonPlus.Widgets.Games {
             model = new ListStore (typeof (Models.CompatibilityTool));
             model.append (new Models.CompatibilityTool (_("Default"), "Default", "",
                 Models.CompatibilityToolRuntimeKind.PROTON));
-            foreach (var ct in launcher.compatibility_tools)
-                model.append (ct);
+            var steam = launcher as Models.Launchers.Steam;
+            if (steam != null) {
+                foreach (var ct in ((!) steam).get_assignable_compatibility_tools ())
+                    model.append (ct);
+            } else {
+                foreach (var ct in launcher.compatibility_tools)
+                    model.append (ct);
+            }
 
             foreach (var game in launcher.games) {
                 var game_row = new GameRow (

--- a/src/widgets/games/games-mass-edit-view.vala
+++ b/src/widgets/games/games-mass-edit-view.vala
@@ -271,6 +271,21 @@ namespace ProtonPlus.Widgets.Games {
                 ProtonPlus.Widgets.Window.present_dialog_for_controller (dialog, (Gtk.Window) this.get_root ());
                 return;
             }
+            if (compatibility_tool_switch.active) {
+                foreach (var row in rows) {
+                    var steam = row.game.launcher as Models.Launchers.Steam;
+                    if (steam != null && !((!) steam).can_assign_compatibility_tool (item.internal_title)) {
+                        var dialog = new Main.ErrorDialog (
+                            _("Compatibility tool cannot be applied"),
+                            _("No games were changed because the selected compatibility tool is no longer available."), ""
+                        );
+                        ProtonPlus.Widgets.Window.present_dialog_for_controller (
+                            dialog, (Gtk.Window) this.get_root ()
+                        );
+                        return;
+                    }
+                }
+            }
             var invalids = new List<string> ();
             var launch_writes = new Gee.HashMap<Models.Games.Steam, LaunchOptionsEditor.LaunchCommandWriteResult> ();
 

--- a/src/widgets/games/launch-options-editor/launch-option-capability-resolver.vala
+++ b/src/widgets/games/launch-options-editor/launch-option-capability-resolver.vala
@@ -151,9 +151,9 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                 return false;
             foreach (var tool in tools) {
                 if (runtime_for_tool (tool) != Models.CompatibilityToolRuntimeKind.PROTON
-                    || tool.path.strip () == "")
+                    || tool.inspection_path.strip () == "")
                     return false;
-                var documentation = documentation_for_tool (tool.path);
+                var documentation = documentation_for_tool (tool.inspection_path);
                 var found = false;
                 foreach (var marker in rule.markers) {
                     if (contains_feature_marker (documentation, marker)) {

--- a/src/widgets/preferences/preferences-dialog.vala
+++ b/src/widgets/preferences/preferences-dialog.vala
@@ -148,7 +148,8 @@ namespace ProtonPlus.Widgets.Preferences {
 
                     var compatibility_tools = new Gee.ArrayList<ProtonPlus.Models.CompatibilityTool> ();
                     foreach (var compatibility_tool in steam_launcher.compatibility_tools) {
-                        if (!Models.Launchers.Steam.is_steam_linux_runtime (compatibility_tool.display_title, compatibility_tool.internal_title))
+                        if (compatibility_tool.is_assignable && compatibility_tool.is_available
+                            && !Models.Launchers.Steam.is_steam_linux_runtime (compatibility_tool.display_title, compatibility_tool.internal_title))
                             compatibility_tools.add (compatibility_tool);
                     }
                     compatibility_tools.sort ((a, b) => {

--- a/src/widgets/tools/tools-migrate-box.vala
+++ b/src/widgets/tools/tools-migrate-box.vala
@@ -100,6 +100,8 @@ namespace ProtonPlus.Widgets.Tools {
             }
 
             foreach (var tool in launcher.compatibility_tools) {
+                if (!tool.is_assignable || !tool.is_available)
+                    continue;
                 if (tool.internal_title != current_tool_name) {
                     if (Models.Launchers.Steam.is_steam_linux_runtime (tool.display_title, tool.internal_title)
                         && !all_steam_linux_runtime_compatible)

--- a/tests/launch-option-capability-resolver-test.vala
+++ b/tests/launch-option-capability-resolver-test.vala
@@ -220,6 +220,18 @@ namespace AppTests.LaunchOptionCapabilityResolverTest {
         assert (current.has (LaunchOptionCapability.LOW_LATENCY_LAYER));
         assert (current.has (LaunchOptionCapability.VULKAN_REFLEX_LAYER));
 
+        var host_mapped = new CompatibilityTool (
+            "Host mapped Proton", "host-mapped",
+            "/usr/share/steam/compatibilitytools.d/HostMapped",
+            CompatibilityToolRuntimeKind.PROTON, first_path, true
+        );
+        var host_mapped_context = resolver.resolve (
+            { CompatibilityToolRuntimeKind.PROTON }, true,
+            components (), GpuVendor.AMD, { host_mapped }
+        );
+        assert (host_mapped_context.has (LaunchOptionCapability.PROTON_FSR4));
+        assert (host_mapped_context.has (LaunchOptionCapability.PROTON_MLFG));
+
         var steam = new ProtonPlus.Models.Launchers.Steam (
             ProtonPlus.Models.Launcher.InstallationTypes.SNAP
         );

--- a/tests/main.vala
+++ b/tests/main.vala
@@ -25,6 +25,7 @@ int main (string[] args) {
     AppTests.FaugusLauncherTest.register_tests ();
     AppTests.MetadataTest.register_tests ();
     AppTests.CompatibilityToolTest.register_tests ();
+    AppTests.SteamCompatibilityToolDiscoveryTest.register_tests ();
     AppTests.InstalledToolInventoryTest.register_tests ();
     AppTests.ParserTest.register_tests ();
     AppTests.LaunchCommandTest.register_tests ();

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,6 +18,7 @@ test_sources = files(
     'faugus-launcher-test.vala',
     'metadata_test.vala',
     'compatibility-tool-test.vala',
+    'steam-compatibility-tool-discovery-test.vala',
     'installed-tool-inventory-test.vala',
     'parser_test.vala',
     'launch-command-test.vala',

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -103,5 +103,27 @@ class SettingsSchemaContractTest(unittest.TestCase):
         self.assertSetEqual(runtime_keys - required_keys, set())
 
 
+class FlatpakManifestPermissionTest(unittest.TestCase):
+    def test_steam_extension_roots_are_read_only_in_both_manifests(self) -> None:
+        required = {
+            "--filesystem=xdg-data/flatpak:ro",
+            "--filesystem=/var/lib/flatpak:ro",
+        }
+        for filename in (
+            "com.vysp3r.ProtonPlus.yml",
+            "com.vysp3r.ProtonPlus.local.yml",
+        ):
+            with self.subTest(manifest=filename):
+                content = (PROJECT_ROOT / filename).read_text(encoding="utf-8")
+                permissions = {
+                    match.group(1)
+                    for match in re.finditer(r"^\s*-\s+(--filesystem=\S+)\s*$", content, re.MULTILINE)
+                }
+                self.assertTrue(required.issubset(permissions))
+                self.assertNotIn("--filesystem=host-root", permissions)
+                self.assertNotIn("--filesystem=xdg-data/flatpak", permissions)
+                self.assertNotIn("--filesystem=/var/lib/flatpak", permissions)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/steam-compatibility-tool-discovery-test.vala
+++ b/tests/steam-compatibility-tool-discovery-test.vala
@@ -1,0 +1,427 @@
+namespace AppTests.SteamCompatibilityToolDiscoveryTest {
+    using GLib;
+    using ProtonPlus.Models;
+    using ProtonPlus.Models.Providers;
+    using ProtonPlus.Services;
+
+    private class StoppedSessionFixture : Object, SteamSessionBackend {
+        public string? get_boot_id () { return "discovery-test"; }
+        public int64 get_monotonic_time_usec () { return 1000000; }
+        public int64 get_clock_ticks_per_second () { return 100; }
+        public NativeProcessQuery query_native_processes () { return new NativeProcessQuery (true); }
+        public FlatpakProcessQuery query_flatpak_processes () { return new FlatpakProcessQuery (true); }
+        public SteamDesktopEntry? find_desktop_entry (string? id) { return null; }
+        public bool is_steamos_gaming_mode () { return false; }
+    }
+
+    public void register_tests () {
+        Test.add_func ("/steam-compatibility-tool-discovery/native-distro-paths-and-projection", test_native_distro_paths_and_projection);
+        Test.add_func ("/steam-compatibility-tool-discovery/steam-library-app-identities", test_steam_library_app_identities);
+        Test.add_func ("/steam-compatibility-tool-discovery/external-tools-stay-out-of-managed-inventory", test_external_tools_stay_out_of_inventory);
+        Test.add_func ("/steam-compatibility-tool-discovery/flatpak-launcher-uses-extension-roots-only", test_flatpak_launcher_uses_extension_roots_only);
+        Test.add_func ("/steam-compatibility-tool-discovery/missing-denied-and-symlink-roots-are-safe", test_unavailable_and_symlink_roots);
+        Test.add_func ("/steam-compatibility-tool-discovery/deduplication-follows-steam-root-precedence", test_deduplication_precedence);
+        Test.add_func ("/steam-compatibility-tool-discovery/exact-title-persistence-and-disappearance", test_persistence_and_disappearance);
+    }
+
+    private string temporary_directory () {
+        try {
+            return DirUtils.make_tmp ("protonplus-steam-tool-discovery-test-XXXXXX");
+        } catch (FileError error) {
+            critical ("Could not create temporary directory: %s", error.message);
+            assert_not_reached ();
+        }
+    }
+
+    private bool delete_directory (string path) {
+        var loop = new MainLoop ();
+        var deleted = false;
+        ProtonPlus.Utils.Filesystem.delete_directory.begin (path, (object, result) => {
+            deleted = ProtonPlus.Utils.Filesystem.delete_directory.end (result);
+            loop.quit ();
+        });
+        loop.run ();
+        return deleted;
+    }
+
+    private string create_tool (
+        string root,
+        string directory_name,
+        string internal_title,
+        string display_title,
+        bool proton = true
+    ) {
+        var path = Path.build_filename (root, directory_name);
+        assert (ProtonPlus.Utils.Filesystem.create_directory (path));
+        ProtonPlus.Utils.Filesystem.create_file (
+            Path.build_filename (path, "compatibilitytool.vdf"),
+            "\"compatibilitytools\"\n{\n\t\"compat_tools\"\n\t{\n\t\t\"%s\"\n\t\t{\n\t\t\t\"display_name\"\t\"%s\"\n\t\t}\n\t}\n}\n".printf (
+                internal_title, display_title
+            )
+        );
+        if (proton) {
+            var proton_path = Path.build_filename (path, "proton");
+            ProtonPlus.Utils.Filesystem.create_file (proton_path, "#!/bin/sh\n");
+            assert (Posix.chmod (proton_path, 0755) == 0);
+        }
+        return path;
+    }
+
+    private string create_steam_library_tool (
+        string root,
+        string directory_name,
+        bool proton
+    ) {
+        var path = Path.build_filename (root, directory_name);
+        assert (ProtonPlus.Utils.Filesystem.create_directory (path));
+        ProtonPlus.Utils.Filesystem.create_file (
+            Path.build_filename (path, "toolmanifest.vdf"),
+            "\"manifest\" { \"version\" \"2\" }"
+        );
+        if (proton) {
+            var proton_path = Path.build_filename (path, "proton");
+            ProtonPlus.Utils.Filesystem.create_file (proton_path, "#!/bin/sh\n");
+            assert (Posix.chmod (proton_path, 0755) == 0);
+        }
+        return path;
+    }
+
+    private string create_flatpak_extension_tool (
+        string runtime_root,
+        string extension_id,
+        string deployment,
+        string directory_name,
+        string internal_title
+    ) {
+        var tools_root = Path.build_filename (
+            runtime_root, extension_id, "x86_64", "stable", deployment,
+            "files", "share", "steam", "compatibilitytools.d"
+        );
+        assert (ProtonPlus.Utils.Filesystem.create_directory (tools_root));
+        return create_tool (tools_root, directory_name, internal_title, directory_name);
+    }
+
+    private ProtonPlus.Models.Launchers.Steam steam_with_discovery (
+        string steam_root,
+        Launcher.InstallationTypes installation_type,
+        SteamCompatibilityToolDiscovery discovery
+    ) {
+        var steam = new ProtonPlus.Models.Launchers.Steam (installation_type, null, discovery);
+        steam.directory = steam_root;
+        steam.installed = true;
+        steam.compatibility_tool_hashtable = new HashTable<uint, string> (null, null);
+        return steam;
+    }
+
+    private CompatibilityTool? find (Gee.Iterable<CompatibilityTool> tools, string internal_title) {
+        foreach (var tool in tools) {
+            if (tool.internal_title == internal_title)
+                return tool;
+        }
+        return null;
+    }
+
+    private void test_native_distro_paths_and_projection () {
+        var root = temporary_directory ();
+        var steam_root = Path.build_filename (root, "Steam");
+        var inspection_root = Path.build_filename (root, "host-usr-tools");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (steam_root));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (inspection_root));
+        create_tool (inspection_root, "CachyOS Proton", "proton-cachyos", "Proton-CachyOS");
+
+        var logical_root = "/usr/share/steam/compatibilitytools.d";
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, true, logical_root, inspection_root, {}
+        );
+        var steam = steam_with_discovery (steam_root, Launcher.InstallationTypes.SYSTEM, discovery);
+        steam.refresh_compatibility_tools ();
+
+        var tool = steam.find_compatibility_tool ("proton-cachyos");
+        assert (tool != null);
+        assert (((!) tool).display_title == "Proton-CachyOS");
+        assert (((!) tool).path == Path.build_filename (logical_root, "CachyOS Proton"));
+        assert (((!) tool).inspection_path == Path.build_filename (inspection_root, "CachyOS Proton"));
+        assert (((!) tool).externally_managed);
+        assert (((!) tool).runtime_kind == CompatibilityToolRuntimeKind.PROTON);
+        assert (steam.can_assign_compatibility_tool ("proton-cachyos"));
+        assert (find (steam.get_assignable_compatibility_tools (), "proton-cachyos") == tool);
+        assert (steam.resolve_effective_proton_executable ("proton-cachyos")
+            == Path.build_filename (logical_root, "CachyOS Proton", "proton"));
+        assert (!((!) steam.resolve_effective_proton_executable ("proton-cachyos")).has_prefix ("/run/host/"));
+
+        var package_root_steam = steam_with_discovery (
+            "/usr/share/steam", Launcher.InstallationTypes.SYSTEM,
+            new SteamCompatibilityToolDiscovery (
+                Launcher.InstallationTypes.SYSTEM, false, logical_root, inspection_root, {}
+            )
+        );
+        var package_group = new Group (
+            "Proton", "", "/compatibilitytools.d", package_root_steam, "proton"
+        );
+        var package_managed_root = package_root_steam.get_managed_tool_directories (package_group).nth_data (0);
+        assert (package_managed_root == Path.build_filename (
+            Environment.get_user_data_dir (), "Steam", "compatibilitytools.d"
+        ));
+        assert (!package_managed_root.has_prefix ("/usr/"));
+        package_group.tools = new Gee.LinkedList<Tool> ();
+        var package_provider_tool = ProviderCatalog.create_tool (definition (), package_group);
+        assert (package_provider_tool != null);
+        package_group.tools.add ((!) package_provider_tool);
+        var release = new Release (
+            "Fixture release", "", "",
+            new ProtonPlus.Models.Assets.Asset (
+                "fixture.tar.gz", "https://example.test/fixture.tar.gz"
+            ),
+            "", 0, "fixture-release"
+        );
+        var install_job = new InstallJob (
+            release, (!) package_provider_tool, InstallJob.Mode.VERSIONED
+        );
+        assert (install_job.install_location.has_prefix (package_managed_root + "/"));
+        assert (!install_job.install_location.has_prefix ("/usr/"));
+
+        assert (delete_directory (root));
+    }
+
+    private ProviderDefinition definition () {
+        return new ProviderDefinition (
+            Category.PROTON, SourceType.GITHUB, "external-match", "Proton-CachyOS", "",
+            "https://example.test/releases", "https://example.test/source", 1,
+            { new VariantDefinition ("default", "default", "$release_name", true) },
+            { InstallLayout.template ("default", "$release_name") }
+        );
+    }
+
+    private void test_steam_library_app_identities () {
+        var root = temporary_directory ();
+        var proton_path = create_steam_library_tool (root, "Proton 11.0", true);
+        var runtime_path = create_steam_library_tool (root, "SteamLinuxRuntime_4", false);
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false,
+            Path.build_filename (root, "system"), Path.build_filename (root, "system"), {}
+        );
+
+        discovery.add_steam_library_app (
+            proton_path, 4628710, "proton_11", "Proton 11.0",
+            CompatibilityToolRuntimeKind.PROTON
+        );
+        discovery.add_steam_library_app (
+            runtime_path, 4183110, "steamlinuxruntime_4", "Steam Linux Runtime 4.0",
+            CompatibilityToolRuntimeKind.NATIVE
+        );
+
+        var proton = find (discovery.get_snapshot (), "proton_11");
+        var runtime = find (discovery.get_snapshot (), "steamlinuxruntime_4");
+        assert (proton != null && ((!) proton).externally_managed);
+        assert (runtime != null && ((!) runtime).externally_managed);
+        assert (discovery.remains_available ((!) proton));
+        assert (discovery.remains_available ((!) runtime));
+
+        assert (FileUtils.remove (Path.build_filename (proton_path, "toolmanifest.vdf")) == 0);
+        assert (!discovery.remains_available ((!) proton));
+        assert (delete_directory (root));
+    }
+
+    private void test_external_tools_stay_out_of_inventory () {
+        var root = temporary_directory ();
+        var steam_root = Path.build_filename (root, "Steam");
+        var managed_root = Path.build_filename (steam_root, "compatibilitytools.d");
+        var inspection_root = Path.build_filename (root, "system-tools");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (managed_root));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (inspection_root));
+        create_tool (inspection_root, "External", "external-match", "Proton-CachyOS");
+
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false, "/usr/share/steam/compatibilitytools.d",
+            inspection_root, {}
+        );
+        var steam = steam_with_discovery (steam_root, Launcher.InstallationTypes.SYSTEM, discovery);
+        var group = new Group ("Proton", "", "/compatibilitytools.d", steam, "proton");
+        group.tools = new Gee.LinkedList<Tool> ();
+        var provider_tool = ProviderCatalog.create_tool (definition (), group);
+        assert (provider_tool != null);
+        group.tools.add ((!) provider_tool);
+        steam.groups = { group };
+
+        steam.refresh_compatibility_tools ();
+        group.refresh_installed_state ();
+        assert (steam.find_compatibility_tool ("external-match") != null);
+        foreach (var entry in group.get_installed_tool_snapshot ())
+            assert (!entry.path.has_prefix (inspection_root));
+        assert (!((!) provider_tool).is_installed ());
+        assert (((!) provider_tool).resolved_installed_entry == null);
+        var managed_directories = steam.get_managed_tool_directories (group);
+        assert (managed_directories.length () == 1);
+        assert (managed_directories.nth_data (0) == managed_root);
+
+        assert (delete_directory (root));
+    }
+
+    private void test_flatpak_launcher_uses_extension_roots_only () {
+        var root = temporary_directory ();
+        var steam_root = Path.build_filename (root, "FlatpakSteam");
+        var distro_root = Path.build_filename (root, "host-usr-tools");
+        var user_runtime = Path.build_filename (root, "user-runtime");
+        var system_runtime = Path.build_filename (root, "system-runtime");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (steam_root));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (distro_root));
+        create_tool (distro_root, "HostOnly", "host-only", "Host only");
+        create_flatpak_extension_tool (
+            user_runtime, "com.valvesoftware.Steam.CompatibilityTool.User", "commit-a",
+            "User Tool", "user-extension"
+        );
+        create_flatpak_extension_tool (
+            user_runtime, "com.valvesoftware.Steam.CompatibilityTool.User", "commit-z",
+            "Active User Tool", "user-extension"
+        );
+        var user_branch = Path.build_filename (
+            user_runtime, "com.valvesoftware.Steam.CompatibilityTool.User",
+            "x86_64", "stable"
+        );
+        assert (Posix.symlink ("commit-z", Path.build_filename (user_branch, "active")) == 0);
+        var utility_deployment = Path.build_filename (
+            system_runtime, "com.valvesoftware.Steam.Utility.System",
+            "x86_64", "stable", "commit-b"
+        );
+        assert (ProtonPlus.Utils.Filesystem.create_directory (utility_deployment));
+        create_tool (utility_deployment, "files", "system-extension", "System Tool", false);
+
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.FLATPAK, false,
+            "/usr/share/steam/compatibilitytools.d", distro_root,
+            { user_runtime, system_runtime }
+        );
+        var steam = steam_with_discovery (steam_root, Launcher.InstallationTypes.FLATPAK, discovery);
+        steam.refresh_compatibility_tools ();
+
+        assert (steam.find_compatibility_tool ("host-only") == null);
+        assert (steam.find_compatibility_tool ("user-extension") != null);
+        assert (((!) steam.find_compatibility_tool ("user-extension")).display_title == "Active User Tool");
+        assert (steam.find_compatibility_tool ("system-extension") != null);
+        assert (((!) steam.find_compatibility_tool ("user-extension")).externally_managed);
+        assert (((!) steam.find_compatibility_tool ("system-extension")).externally_managed);
+
+        assert (delete_directory (root));
+    }
+
+    private void test_unavailable_and_symlink_roots () {
+        var root = temporary_directory ();
+        var real_root = Path.build_filename (root, "real-root");
+        var symlink_root = Path.build_filename (root, "root-link");
+        var child_target_root = Path.build_filename (root, "child-targets");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (real_root));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (child_target_root));
+        var target = create_tool (child_target_root, "Target", "symlink-target", "Symlink target");
+        assert (Posix.symlink (target, Path.build_filename (real_root, "Linked child")) == 0);
+        assert (Posix.symlink (real_root, symlink_root) == 0);
+
+        var missing = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false, "/logical", Path.build_filename (root, "missing"), {}
+        );
+        missing.discover_launcher_roots (Path.build_filename (root, "missing-managed"));
+        assert (missing.get_snapshot ().size == 0);
+
+        var root_link = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false, "/logical", symlink_root, {}
+        );
+        root_link.discover_launcher_roots (Path.build_filename (root, "missing-managed"));
+        assert (root_link.get_snapshot ().size == 0);
+
+        var child_link = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false, "/logical", real_root, {}
+        );
+        child_link.discover_launcher_roots (Path.build_filename (root, "missing-managed"));
+        assert (child_link.get_snapshot ().size == 0);
+
+        var denied_root = Path.build_filename (root, "denied");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (denied_root));
+        assert (Posix.chmod (denied_root, 0000) == 0);
+        var denied = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false, "/logical", denied_root, {}
+        );
+        denied.discover_launcher_roots (Path.build_filename (root, "missing-managed"));
+        assert (Posix.chmod (denied_root, 0700) == 0);
+
+        assert (delete_directory (root));
+    }
+
+    private void test_deduplication_precedence () {
+        var root = temporary_directory ();
+        var steam_root = Path.build_filename (root, "Steam");
+        var managed_root = Path.build_filename (steam_root, "compatibilitytools.d");
+        var system_root = Path.build_filename (root, "system-tools");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (managed_root));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (system_root));
+        create_tool (managed_root, "Managed", "proton_11", "Managed winner");
+        var external_path = create_steam_library_tool (system_root, "Proton 11.0", true);
+
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, true,
+            "/usr/share/steam/compatibilitytools.d", system_root, {}
+        );
+        discovery.add_steam_library_app (
+            external_path, 4628710, "proton_11", "Proton 11.0",
+            CompatibilityToolRuntimeKind.PROTON
+        );
+        discovery.discover_launcher_roots (managed_root);
+        var snapshot = discovery.get_snapshot ();
+        assert (snapshot.size == 1);
+        assert (snapshot[0].display_title == "Managed winner");
+        assert (!snapshot[0].externally_managed);
+
+        assert (delete_directory (root));
+    }
+
+    private void test_persistence_and_disappearance () {
+        var root = temporary_directory ();
+        var steam_root = Path.build_filename (root, "Steam");
+        var config_root = Path.build_filename (steam_root, "config");
+        var system_root = Path.build_filename (root, "system-tools");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (config_root));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (system_root));
+        var tool_path = create_tool (
+            system_root, "Distro Tool", "Exact Internal Title", "Friendly distro title"
+        );
+        var config_path = Path.build_filename (config_root, "config.vdf");
+        ProtonPlus.Utils.Filesystem.create_file (
+            config_path,
+            "\"InstallConfigStore\"\n{\n\t\"Software\"\n\t{\n\t\t\"Valve\"\n\t\t{\n\t\t\t\"Steam\"\n\t\t\t{\n\t\t\t}\n\t\t}\n\t}\n}\n"
+        );
+
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false,
+            "/usr/share/steam/compatibilitytools.d", system_root, {}
+        );
+        var steam = steam_with_discovery (steam_root, Launcher.InstallationTypes.SYSTEM, discovery);
+        steam.refresh_compatibility_tools ();
+        var sessions = new SteamSessionService (new StoppedSessionFixture ());
+        var manager = new SteamRestartManager (
+            sessions, new SteamRestartStateStore (Path.build_filename (root, "restart-state.json"))
+        );
+        var service = new SteamConfigurationService (sessions, manager);
+        manager.configure_configuration_reconciler (service);
+        SteamConfigurationService.configure (service);
+        var game = new ProtonPlus.Models.Games.Steam (42, "Fixture", "Fixture", 0, root, steam);
+
+        assert (game.change_compatibility_tool ("Exact Internal Title"));
+        var changed = ProtonPlus.Utils.Filesystem.get_file_content (config_path);
+        assert (changed.contains ("Exact Internal Title"));
+        assert (!changed.contains ("Friendly distro title"));
+
+        assert (FileUtils.remove (Path.build_filename (tool_path, "compatibilitytool.vdf")) == 0);
+        assert (!steam.can_assign_compatibility_tool ("Exact Internal Title"));
+        assert (!game.change_compatibility_tool ("Exact Internal Title"));
+        steam.compatibility_tool_hashtable.set (42, "Exact Internal Title");
+        steam.refresh_compatibility_tools ();
+        var stale = steam.find_compatibility_tool ("Exact Internal Title");
+        assert (stale != null);
+        assert (!((!) stale).is_available);
+        assert (!((!) stale).is_assignable);
+        assert (((!) stale).display_title.contains ("Exact Internal Title"));
+        assert (((!) stale).display_title != "Default");
+        assert (find (steam.get_assignable_compatibility_tools (), "Exact Internal Title") == null);
+
+        SteamConfigurationService.reset_configuration ();
+        assert (delete_directory (root));
+    }
+}

--- a/tests/steam_test.vala
+++ b/tests/steam_test.vala
@@ -92,6 +92,7 @@ namespace AppTests.SteamTest {
         Test.add_func ("/steam/awacy-catalog-deduplicates-and-caches", test_awacy_catalog_deduplicates_and_caches);
         Test.add_func ("/steam/awacy-catalog-bounds-optional-request", test_awacy_catalog_bounds_optional_request);
         Test.add_func ("/steam/local-library-does-not-wait-for-awacy", test_local_library_does_not_wait_for_awacy);
+        Test.add_func ("/steam/library-compatibility-tools-use-stable-identities", test_library_compatibility_tools_use_stable_identities);
     }
 
     private void test_linux_runtime_detection () {
@@ -493,6 +494,71 @@ namespace AppTests.SteamTest {
         assert (notified);
         assert (((!) game).awacy_name == "fixture-game");
         assert (((!) game).awacy_status == "Running");
+        assert (delete_directory (root));
+    }
+
+    private void test_library_compatibility_tools_use_stable_identities () {
+        var root = temporary_directory ();
+        var config_directory = Path.build_filename (root, "config");
+        var steamapps_directory = Path.build_filename (root, "steamapps");
+        assert (ProtonPlus.Utils.Filesystem.create_directory (config_directory));
+        assert (ProtonPlus.Utils.Filesystem.create_directory (
+            Path.build_filename (steamapps_directory, "common")
+        ));
+        assert (ProtonPlus.Utils.Filesystem.modify_file (
+            Path.build_filename (config_directory, "config.vdf"),
+            "\"InstallConfigStore\" { \"Software\" { \"Valve\" { \"Steam\" { } } } }"
+        ));
+        assert (ProtonPlus.Utils.Filesystem.modify_file (
+            Path.build_filename (steamapps_directory, "libraryfolders.vdf"),
+            "\"libraryfolders\" { \"0\" { \"path\" \"%s\" \"apps\" { \"4628710\" \"1\" \"2805730\" \"1\" \"4183110\" \"1\" } } }".printf (root)
+        ));
+
+        var appids = new uint[] { 4628710, 2805730, 4183110 };
+        var names = new string[] { "Proton 11.0", "Proton 9.0", "Steam Linux Runtime 4.0" };
+        var directories = new string[] { "Proton 11.0", "Proton 9.0 (Beta)", "SteamLinuxRuntime_4" };
+        for (var index = 0; index < appids.length; index++) {
+            assert (ProtonPlus.Utils.Filesystem.modify_file (
+                Path.build_filename (steamapps_directory, "appmanifest_%u.acf".printf (appids[index])),
+                "\"AppState\" { \"appid\" \"%u\" \"name\" \"%s\" \"installdir\" \"%s\" }".printf (
+                    appids[index], names[index], directories[index]
+                )
+            ));
+            var tool_path = Path.build_filename (steamapps_directory, "common", directories[index]);
+            assert (ProtonPlus.Utils.Filesystem.create_directory (tool_path));
+            assert (ProtonPlus.Utils.Filesystem.modify_file (
+                Path.build_filename (tool_path, "toolmanifest.vdf"),
+                "\"manifest\" { \"version\" \"2\" }"
+            ));
+            if (appids[index] != 4183110)
+                create_executable_fixture (Path.build_filename (tool_path, "proton"), "#!/bin/sh\n");
+        }
+
+        var unavailable_system_root = Path.build_filename (root, "system-tools");
+        var discovery = new SteamCompatibilityToolDiscovery (
+            Launcher.InstallationTypes.SYSTEM, false,
+            unavailable_system_root, unavailable_system_root, {}
+        );
+        var catalog = new ProtonPlus.Models.Games.AwacyGameCatalog (
+            new ManualAwacyGameSource (), 0
+        );
+        var steam = new ProtonPlus.Models.Launchers.Steam (
+            Launcher.InstallationTypes.SYSTEM, catalog, discovery
+        );
+        steam.directory = root;
+        steam.groups = {};
+
+        assert (load_steam_library (steam));
+        var proton_11 = steam.find_compatibility_tool ("proton_11");
+        var proton_9 = steam.find_compatibility_tool ("proton_9");
+        var runtime = steam.find_compatibility_tool ("steamlinuxruntime_4");
+        assert (proton_11 != null && ((!) proton_11).display_title == "Proton 11.0");
+        assert (proton_9 != null && ((!) proton_9).display_title == "Proton 9.0");
+        assert (runtime != null && ((!) runtime).runtime_kind == CompatibilityToolRuntimeKind.NATIVE);
+        assert (steam.can_assign_compatibility_tool ("proton_11"));
+        assert (steam.can_assign_compatibility_tool ("proton_9"));
+        assert (steam.can_assign_compatibility_tool ("steamlinuxruntime_4"));
+        assert (steam.get_assignable_compatibility_tools ().size == 3);
         assert (delete_directory (root));
     }
 


### PR DESCRIPTION
This adds support for tools installed with package manager and Flatpak extensions.