### PR TITLE
Misc build fixes

### DIFF
--- a/src/models/steam-change-receipt.vala
+++ b/src/models/steam-change-receipt.vala
@@ -76,7 +76,7 @@ namespace ProtonPlus.Models {
 
         public static string fingerprint (string value, bool present) {
             var checksum = new Checksum (ChecksumType.SHA256);
-            var material = (present ? "present\u001f" : "absent\u001f") + value;
+            var material = (present ? "present\x1f" : "absent\x1f") + value;
             checksum.update (material.data, material.length);
             return checksum.get_string ();
         }
@@ -139,7 +139,7 @@ namespace ProtonPlus.Models {
                 var identity = configuration_intent != null
                     ? "configuration-intent"
                     : kind_to_identifier (kind);
-                return "%s\u001f%s\u001f%s".printf (target.id, identity, resource_key);
+                return "%s\x1f%s\x1f%s".printf (target.id, identity, resource_key);
             }
         }
 

--- a/src/services/steam-configuration-service.vala
+++ b/src/services/steam-configuration-service.vala
@@ -37,7 +37,7 @@ namespace ProtonPlus.Services {
     }
 
     public class SteamConfigurationService : Object, SteamConfigurationReconciler {
-        private const string ABSENT = "\u001eprotonplus-absent";
+        private const string ABSENT = "\x1eprotonplus-absent";
         private SteamSessionService sessions;
         private SteamRestartManager manager;
         private SteamShortcutMutator shortcut_mutator;

--- a/src/services/steam-restart-state-store.vala
+++ b/src/services/steam-restart-state-store.vala
@@ -233,7 +233,7 @@ namespace ProtonPlus.Services {
             if (schema_version == 1) {
                 if (!object.has_member ("baseline")) return null;
                 var baseline = object.get_string_member ("baseline");
-                const string legacy_absent = "\u001eprotonplus-absent";
+                const string legacy_absent = "\x1eprotonplus-absent";
                 var baseline_present = baseline != legacy_absent;
                 var desired_present = desired != legacy_absent;
                 return new SteamConfigurationIntent (file, operation, path, field_id,

--- a/src/utils/cpu-probe.c
+++ b/src/utils/cpu-probe.c
@@ -10,6 +10,39 @@
 #if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
 #include <cpuid.h>
 
+struct _ProtonPlusCpuFeatureProbe {
+    gboolean available;
+    gboolean cmpxchg16b;
+    gboolean lahf_sahf;
+    gboolean popcnt;
+    gboolean sse3;
+    gboolean sse4_1;
+    gboolean sse4_2;
+    gboolean ssse3;
+    gboolean avx;
+    gboolean avx2;
+    gboolean bmi1;
+    gboolean bmi2;
+    gboolean f16c;
+    gboolean fma;
+    gboolean lzcnt;
+    gboolean movbe;
+    gboolean osxsave;
+    gboolean xcr0_xmm;
+    gboolean xcr0_ymm;
+    gboolean avx512f;
+    gboolean avx512bw;
+    gboolean avx512cd;
+    gboolean avx512dq;
+    gboolean avx512vl;
+    gboolean xcr0_opmask;
+    gboolean xcr0_zmm_hi256;
+    gboolean xcr0_hi16_zmm;
+    gboolean aarch64_crc32;
+    gboolean aarch64_lse_atomics;
+    gboolean aarch64_rdma;
+};
+
 static uint64_t
 read_xcr0 (void)
 {

--- a/src/utils/cpu-probe.c
+++ b/src/utils/cpu-probe.c
@@ -2,14 +2,6 @@
 
 #include <stdint.h>
 
-#if defined(__aarch64__) && defined(__linux__)
-#include <asm/hwcap.h>
-#include <sys/auxv.h>
-#endif
-
-#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
-#include <cpuid.h>
-
 struct _ProtonPlusCpuFeatureProbe {
     gboolean available;
     gboolean cmpxchg16b;
@@ -42,6 +34,14 @@ struct _ProtonPlusCpuFeatureProbe {
     gboolean aarch64_lse_atomics;
     gboolean aarch64_rdma;
 };
+
+#if defined(__aarch64__) && defined(__linux__)
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#endif
+
+#if (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) || defined(__clang__))
+#include <cpuid.h>
 
 static uint64_t
 read_xcr0 (void)

--- a/src/utils/cpu-probe.h
+++ b/src/utils/cpu-probe.h
@@ -2,37 +2,6 @@
 
 #include <glib.h>
 
-typedef struct _ProtonPlusCpuFeatureProbe {
-    gboolean available;
-    gboolean cmpxchg16b;
-    gboolean lahf_sahf;
-    gboolean popcnt;
-    gboolean sse3;
-    gboolean sse4_1;
-    gboolean sse4_2;
-    gboolean ssse3;
-    gboolean avx;
-    gboolean avx2;
-    gboolean bmi1;
-    gboolean bmi2;
-    gboolean f16c;
-    gboolean fma;
-    gboolean lzcnt;
-    gboolean movbe;
-    gboolean osxsave;
-    gboolean xcr0_xmm;
-    gboolean xcr0_ymm;
-    gboolean avx512f;
-    gboolean avx512bw;
-    gboolean avx512cd;
-    gboolean avx512dq;
-    gboolean avx512vl;
-    gboolean xcr0_opmask;
-    gboolean xcr0_zmm_hi256;
-    gboolean xcr0_hi16_zmm;
-    gboolean aarch64_crc32;
-    gboolean aarch64_lse_atomics;
-    gboolean aarch64_rdma;
-} ProtonPlusCpuFeatureProbe;
+typedef struct _ProtonPlusCpuFeatureProbe ProtonPlusCpuFeatureProbe;
 
 void protonplus_cpu_get_feature_probe (ProtonPlusCpuFeatureProbe *out_probe);

--- a/tests/steam_test.vala
+++ b/tests/steam_test.vala
@@ -120,7 +120,7 @@ namespace AppTests.SteamTest {
         assert (ProtonPlus.Utils.Filesystem.create_directory (windows_directory));
         assert (ProtonPlus.Utils.Filesystem.create_directory (native_directory));
         create_executable_fixture (Path.build_filename (windows_directory, "game.exe"), "MZfixture");
-        create_executable_fixture (Path.build_filename (native_directory, "game"), "\u007fELFfixture");
+        create_executable_fixture (Path.build_filename (native_directory, "game"), "\x7f" + "ELFfixture");
 
         var steam = fixture_steam (root);
         steam.games = new List<Game> ();
@@ -188,7 +188,7 @@ namespace AppTests.SteamTest {
         var game_directory = Path.build_filename (root, "steamapps", "common", "NativeGame");
         assert (ProtonPlus.Utils.Filesystem.create_directory (config_directory));
         assert (ProtonPlus.Utils.Filesystem.create_directory (game_directory));
-        create_executable_fixture (Path.build_filename (game_directory, "game"), "\u007fELFfixture");
+        create_executable_fixture (Path.build_filename (game_directory, "game"), "\x7f" + "ELFfixture");
         assert (ProtonPlus.Utils.Filesystem.modify_file (
             Path.build_filename (config_directory, "config.vdf"),
             "\"InstallConfigStore\"\n{\n\t\"Software\"\n\t{\n\t\t\"Valve\"\n\t\t{\n\t\t\t\"Steam\"\n\t\t\t{\n\t\t\t}\n\t\t}\n\t}\n}\n"


### PR DESCRIPTION
*Thank you for contributing to ProtonPlus! Please complete the relevant sections below.*

### Category

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [x] Build related changes
- [ ] Documentation
- [ ] Translation
- [ ] Other (Please specify!)

### Overview

I wanted to upgrade my Gentoo package to the new `0.6.X` (see https://github.com/xarblu/xarblu-overlay/commit/eb9b1728796dbebcf2679432ffddf304a258d4fe) and faced these 2 issues during compilation with `vala-0.56.19` and `clang-23.1.0-rc3` (not sure if it's an issue specific to this toolchain).

The first issue was `clang` not liking the (for example) `\u001f` escape sequences for control characters which aren't allowed in C string literals (see https://en.cppreference.com/c/language/escape).
These were changed to their hex (e.g. `\x1f`) forms.

The second issue was `valac` seemingly redefining the `_ProtonPlusCpuFeatureProbe` `struct` which I fixed by making the `struct` in the C header opaque (moving the definition to `cpu-probe.c`) so the generated `system.c` and `cpu-probe.c` each only have their own definition of the `struct`.

The commit messages each have some more details if you want to look at them :)

### Issue Number

N/A

### New Variables or Dependencies

N/A

### How to Test

I used the test feature from Gentoo's package manager `portage` which uses `meson test` internally and all tests passed there.

### Screenshots (if applicable)

N/A

### Checklist

- [x] My code follows the project's [style guide](https://github.com/Vysp3r/ProtonPlus/blob/main/CONTRIBUTING.md#style-guide).
- [x] I have tested my changes and verified that they work as expected.
- [ ] ~~I have updated the documentation accordingly (if applicable).~~
- [ ] ~~I have updated the translations by running `./scripts/build.sh translations` (if applicable).~~
- [x] I have checked for existing pull requests that cover these changes.
