### PR TITLE
Fix stale release catalog cache refresh

### DIFF
--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -92,8 +92,6 @@
       <description>
         <ul>
           <li>🐛 Fixed release catalogs sometimes remaining stale until application data was refreshed manually</li>
-          <li>🐛 Improved build compatibility on non-x86 architectures and with stricter C compilers</li>
-          <li>🔒 Reduced Flatpak device permissions while preserving controller support on older Flatpak versions</li>
           <li>🌐 Updated Czech, German, French, Portuguese, Russian, Japanese, and Spanish localizations</li>
         </ul>
       </description>

--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -88,6 +88,16 @@
   </screenshots>
 
   <releases>
+    <release version="0.6.5" date="2026-08-30">
+      <description>
+        <ul>
+          <li>🐛 Fixed release catalogs sometimes remaining stale until application data was refreshed manually</li>
+          <li>🐛 Improved build compatibility on non-x86 architectures and with stricter C compilers</li>
+          <li>🔒 Reduced Flatpak device permissions while preserving controller support on older Flatpak versions</li>
+          <li>🌐 Updated Czech, German, French, Portuguese, Russian, Japanese, and Spanish localizations</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.4" date="2026-08-13">
       <description>
         <ul>

--- a/src/models/release-catalog.vala
+++ b/src/models/release-catalog.vala
@@ -158,7 +158,7 @@ namespace ProtonPlus.Models {
             }
         }
 
-        internal static bool cache_timestamp_is_fresh (string last_updated, DateTime now) {
+        public static bool cache_timestamp_is_fresh (string last_updated, DateTime now) {
             if (last_updated == "")
                 return false;
 

--- a/src/models/release-catalog.vala
+++ b/src/models/release-catalog.vala
@@ -4,6 +4,7 @@ namespace ProtonPlus.Models {
     // this class applies the result to the catalog and its persisted snapshot.
     public class ReleaseCatalog : Object {
         public const int RELEASE_PAGE_SIZE = 25;
+        public const int64 CACHE_TTL = TimeSpan.HOUR;
 
         private Providers.ProviderDefinition? definition;
         private ProtonPlus.Providers.Sources.ReleaseSource? release_source;
@@ -70,16 +71,18 @@ namespace ProtonPlus.Models {
                 return ReleaseCatalogResult.success (releases);
             }
 
-            if (releases.size > 0 && !force_refresh)
+            if (releases.size > 0 && !force_refresh && cache_is_fresh (last_updated))
                 return ReleaseCatalogResult.success (releases);
 
             loading = true;
-            if (!force_refresh && cache != null) {
+            if (!force_refresh && releases.size == 0 && cache != null) {
                 var snapshot = yield cache.load ();
                 if (snapshot != null && snapshot.releases.size > 0 && cached_releases_match_definition (snapshot.releases)) {
                     apply_snapshot (snapshot);
-                    loading = false;
-                    return ReleaseCatalogResult.success (releases);
+                    if (cache_is_fresh (snapshot.last_updated)) {
+                        loading = false;
+                        return ReleaseCatalogResult.success (releases);
+                    }
                 }
             }
 
@@ -153,6 +156,22 @@ namespace ProtonPlus.Models {
                     return ReleaseLookupResult.empty ();
                 requested_page = release_page.next_page;
             }
+        }
+
+        internal static bool cache_timestamp_is_fresh (string last_updated, DateTime now) {
+            if (last_updated == "")
+                return false;
+
+            var updated = new DateTime.from_iso8601 (last_updated, null);
+            if (updated == null)
+                return false;
+
+            var age = now.difference (updated);
+            return age >= 0 && age < CACHE_TTL;
+        }
+
+        private bool cache_is_fresh (string timestamp) {
+            return cache_timestamp_is_fresh (timestamp, new DateTime.now_local ());
         }
 
         private async Tools.ReleasePageResult fetch_page (int requested_page) {

--- a/tests/main.vala
+++ b/tests/main.vala
@@ -47,6 +47,7 @@ int main (string[] args) {
     AppTests.CliTest.register_tests ();
     AppTests.ReleaseIdentityTest.register_tests ();
     AppTests.ReleasePageTest.register_tests ();
+    AppTests.ReleaseCatalogTest.register_tests ();
     AppTests.VariantSettingsTest.register_tests ();
     AppTests.InstallLayoutTest.register_tests ();
     AppTests.CompatibilityProcessGuardTest.register_tests ();

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -39,6 +39,7 @@ test_sources = files(
     'cli_test.vala',
     'release_identity_test.vala',
     'release_page_test.vala',
+    'release-catalog-test.vala',
     'variant_settings_test.vala',
     'install_layout_test.vala',
     'compatibility-process-guard-test.vala',

--- a/tests/release-catalog-test.vala
+++ b/tests/release-catalog-test.vala
@@ -1,0 +1,41 @@
+namespace AppTests.ReleaseCatalogTest {
+    using GLib;
+    using ProtonPlus.Models;
+
+    public void register_tests () {
+        Test.add_func ("/release-catalog/cache-timestamp-fresh", test_cache_timestamp_fresh);
+        Test.add_func ("/release-catalog/cache-timestamp-expired", test_cache_timestamp_expired);
+        Test.add_func ("/release-catalog/cache-timestamp-invalid", test_cache_timestamp_invalid);
+        Test.add_func ("/release-catalog/cache-timestamp-future", test_cache_timestamp_future);
+    }
+
+    private DateTime fixed_now () {
+        var now = new DateTime.from_iso8601 ("2026-08-30T12:00:00Z", null);
+        assert (now != null);
+        return (!) now;
+    }
+
+    private void test_cache_timestamp_fresh () {
+        var now = fixed_now ();
+        var updated = now.add_minutes (-59);
+        assert (ReleaseCatalog.cache_timestamp_is_fresh (updated.format_iso8601 (), now));
+    }
+
+    private void test_cache_timestamp_expired () {
+        var now = fixed_now ();
+        var updated = now.add_hours (-1);
+        assert (!ReleaseCatalog.cache_timestamp_is_fresh (updated.format_iso8601 (), now));
+    }
+
+    private void test_cache_timestamp_invalid () {
+        var now = fixed_now ();
+        assert (!ReleaseCatalog.cache_timestamp_is_fresh ("", now));
+        assert (!ReleaseCatalog.cache_timestamp_is_fresh ("not-a-timestamp", now));
+    }
+
+    private void test_cache_timestamp_future () {
+        var now = fixed_now ();
+        var updated = now.add_minutes (1);
+        assert (!ReleaseCatalog.cache_timestamp_is_fresh (updated.format_iso8601 (), now));
+    }
+}

--- a/tests/release_page_test.vala
+++ b/tests/release_page_test.vala
@@ -362,7 +362,8 @@ namespace AppTests.ReleasePageTest {
         var cache = new ReleaseCatalogCache ("cached-tool", "Fixture provider");
         var cached = new LinkedList<Release> ();
         cached.add (cached_release ("v1", "1"));
-        save_snapshot (cache, new ReleaseCatalogSnapshot (cached, 4, true, "2026-07-26T00:00:00Z"));
+        var now = new DateTime.now_local ().format_iso8601 ();
+        save_snapshot (cache, new ReleaseCatalogSnapshot (cached, 4, true, now));
 
         var source = new FixtureReleaseSource ();
         var value = catalog ("cached-tool", definition (), source);

--- a/tests/release_page_test.vala
+++ b/tests/release_page_test.vala
@@ -84,7 +84,7 @@ namespace AppTests.ReleasePageTest {
         Test.add_func ("/release-catalog/github-actions-scans-filtered-pages", test_github_actions_scanning);
         Test.add_func ("/release-catalog/github-actions-later-page-failure", test_github_actions_later_page_failure);
         Test.add_func ("/release-catalog/github-actions-proton-tkg-cache-reuse", test_github_actions_proton_tkg_cache_reuse);
-        Test.add_func ("/release-catalog/in-memory-state-skips-cache-and-network", test_in_memory_state_skips_network);
+        Test.add_func ("/release-catalog/in-memory-state-without-timestamp-refreshes-network", test_in_memory_state_without_timestamp_refreshes_network);
         Test.add_func ("/release-catalog/valid-cache-skips-network", test_valid_cache_skips_network);
         Test.add_func ("/release-catalog/missing-and-malformed-cache-fetches", test_missing_and_malformed_cache_fetches);
         Test.add_func ("/release-catalog/stale-filtered-release-refreshes", test_stale_filtered_release_refreshes);
@@ -338,7 +338,7 @@ namespace AppTests.ReleasePageTest {
         assert (cached_source.requested_pages.size == 0);
     }
 
-    private void test_in_memory_state_skips_network () {
+    private void test_in_memory_state_without_timestamp_refreshes_network () {
         cache_path ();
         var source = new FixtureReleaseSource ();
         var value = catalog ("memory-tool", definition (), source);
@@ -353,7 +353,8 @@ namespace AppTests.ReleasePageTest {
 
         var result = load (value, false);
         assert (result.releases.size == 1 && result.succeeded);
-        assert (value.releases[0].title == "v1" && source.requested_pages.size == 0);
+        assert (value.releases[0].title == "v1");
+        assert (source.requested_pages.size == 1 && source.requested_pages[0] == 1);
     }
 
     private void test_valid_cache_skips_network () {


### PR DESCRIPTION
Adds a one-hour TTL for release catalogs, refreshes stale in-memory and persisted catalog data, retains stale data on refresh failures, adds regression tests, and updates the 0.6.5 AppStream release notes.

Fixes #1261
Fixes #1262