### PR TITLE
Fix Flatpak scheduled systemd updates

### DIFF
--- a/com.vysp3r.ProtonPlus.yml
+++ b/com.vysp3r.ProtonPlus.yml
@@ -52,7 +52,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/Vysp3r/ProtonPlus.git
-        tag: v0.6.5
+        tag: v0.6.6
         x-checker-data:
           type: git
           tag-pattern: ^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.\-]+)?)$

--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -88,6 +88,14 @@
   </screenshots>
 
   <releases>
+    <release version="0.6.6" date="2026-09-03">
+      <description>
+        <ul>
+          <li>🐛 Fixed scheduled tool updates not working when ProtonPlus is installed as a Flatpak</li>
+          <li>🌐 Updated Spanish localization</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.5" date="2026-08-30">
       <description>
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'com.vysp3r.ProtonPlus',
     ['c', 'vala'],
-    version: '0.6.5',
+    version: '0.6.6',
     meson_version: '>= 1.0.0',
     default_options: [
         'warning_level=2',

--- a/src/main.vala
+++ b/src/main.vala
@@ -1,5 +1,16 @@
 namespace ProtonPlus {
     public static int main (string[] args) {
+        if (FileUtils.test ("/.flatpak-info", FileTest.IS_REGULAR)) {
+            var host_config_dir = Environment.get_variable ("HOST_XDG_CONFIG_HOME");
+            if (host_config_dir == null || ((!) host_config_dir).strip () == "") {
+                Environment.set_variable (
+                    "HOST_XDG_CONFIG_HOME",
+                    Path.build_filename (Environment.get_home_dir (), ".config"),
+                    true
+                );
+            }
+        }
+
         if (args.length > 1) {
             Globals.load ();
             Globals.setupLanguage ();

--- a/src/services/migrations/manager.vala
+++ b/src/services/migrations/manager.vala
@@ -13,6 +13,7 @@ namespace ProtonPlus.Services.Migrations {
         private void register_migrations () {
             this.migrations.add ( new Versions.v0_5_21 ());
             this.migrations.add ( new Versions.v0_6_0 ());
+            this.migrations.add ( new Versions.v0_6_6 ());
         }
 
         public async void check_and_migrate (string current_version) {

--- a/src/services/migrations/versions/meson.build
+++ b/src/services/migrations/versions/meson.build
@@ -1,5 +1,6 @@
 sources += files(
     'v0.5.21.vala',
     'v0.6.0.vala',
+    'v0.6.6.vala',
 )
 

--- a/src/services/migrations/versions/v0.6.6.vala
+++ b/src/services/migrations/versions/v0.6.6.vala
@@ -18,7 +18,8 @@ namespace ProtonPlus.Services.Migrations.Versions {
             if (!is_flatpak)
                 return;
 
-            var legacy_systemd_dir = Path.build_filename (user_config_dir, "systemd", "user");
+            var legacy_systemd_parent = Path.build_filename (user_config_dir, "systemd");
+            var legacy_systemd_dir = Path.build_filename (legacy_systemd_parent, "user");
             foreach (var unit_name in new string[] { "protonplus.service", "protonplus.timer" }) {
                 var unit_path = Path.build_filename (legacy_systemd_dir, unit_name);
                 if (!FileUtils.test (unit_path, FileTest.EXISTS))
@@ -27,6 +28,11 @@ namespace ProtonPlus.Services.Migrations.Versions {
                 if (FileUtils.remove (unit_path) != 0)
                     warning ("Could not remove legacy Flatpak systemd unit: %s", unit_path);
             }
+
+            // Remove the legacy directories only when they are empty. This
+            // preserves any unrelated user systemd files that may be present.
+            if (DirUtils.remove (legacy_systemd_dir) == 0)
+                DirUtils.remove (legacy_systemd_parent);
         }
 
         public void post_migrate (MigrationContext? context = null) {

--- a/src/services/migrations/versions/v0.6.6.vala
+++ b/src/services/migrations/versions/v0.6.6.vala
@@ -1,0 +1,35 @@
+namespace ProtonPlus.Services.Migrations.Versions {
+
+    public class v0_6_6 : Object, IMigration {
+        public string version { get; default = "0.6.6"; }
+
+        public async void migrate () {
+            print ("Migration: Performing specific changes for version 0.6.6…\n");
+            cleanup_legacy_flatpak_systemd_units (
+                ProtonPlus.Globals.IS_FLATPAK,
+                Environment.get_user_config_dir ()
+            );
+        }
+
+        public static void cleanup_legacy_flatpak_systemd_units (
+            bool is_flatpak,
+            string user_config_dir
+        ) {
+            if (!is_flatpak)
+                return;
+
+            var legacy_systemd_dir = Path.build_filename (user_config_dir, "systemd", "user");
+            foreach (var unit_name in new string[] { "protonplus.service", "protonplus.timer" }) {
+                var unit_path = Path.build_filename (legacy_systemd_dir, unit_name);
+                if (!FileUtils.test (unit_path, FileTest.EXISTS))
+                    continue;
+
+                if (FileUtils.remove (unit_path) != 0)
+                    warning ("Could not remove legacy Flatpak systemd unit: %s", unit_path);
+            }
+        }
+
+        public void post_migrate (MigrationContext? context = null) {
+        }
+    }
+}

--- a/src/utils/system.vala
+++ b/src/utils/system.vala
@@ -567,6 +567,21 @@ namespace ProtonPlus.Utils {
             open_uri (file_uri_for_path (path));
         }
 
+        public static string get_systemd_user_dir_for_environment (
+            bool is_flatpak,
+            string user_config_dir,
+            string? host_user_config_dir
+        ) {
+            var config_dir = user_config_dir;
+            if (is_flatpak && host_user_config_dir != null) {
+                var host_config_dir = ((!) host_user_config_dir).strip ();
+                if (host_config_dir != "")
+                    config_dir = host_config_dir;
+            }
+
+            return Path.build_filename (config_dir, "systemd", "user");
+        }
+
         public static void systemd_handler () {
             systemd_update_pending = true;
             if (systemd_update_running)
@@ -600,13 +615,18 @@ namespace ProtonPlus.Utils {
                 "/usr/bin/flatpak run com.vysp3r.ProtonPlus" :
                 Environment.find_program_in_path ("protonplus") ?? "protonplus";
             string exec_start = "%s update all".printf (executable);
+            var systemd_dir = get_systemd_user_dir_for_environment (
+                Globals.IS_FLATPAK,
+                Environment.get_user_config_dir (),
+                Environment.get_variable ("HOST_XDG_CONFIG_HOME")
+            );
 
             try {
                 var service_resource = resources_lookup_data ("/com/vysp3r/ProtonPlus/protonplus.service", ResourceLookupFlags.NONE);
                 var timer_resource = resources_lookup_data ("/com/vysp3r/ProtonPlus/protonplus.timer", ResourceLookupFlags.NONE);
                 systemd_timer_manager = new SystemdTimerManager (
                     new HostSystemctlBackend (),
-                    Path.build_filename (Environment.get_user_config_dir (), "systemd", "user"),
+                    systemd_dir,
                     Parser.data_to_string (service_resource.get_data ()),
                     Parser.data_to_string (timer_resource.get_data ()),
                     exec_start

--- a/tests/main.vala
+++ b/tests/main.vala
@@ -28,6 +28,7 @@ int main (string[] args) {
     AppTests.WebTest.register_tests ();
     AppTests.SystemPathTest.register_tests ();
     AppTests.SystemdTimerTest.register_tests ();
+    AppTests.MigrationV0_6_6Test.register_tests ();
     AppTests.FaugusLauncherTest.register_tests ();
     AppTests.MetadataTest.register_tests ();
     AppTests.CompatibilityToolTest.register_tests ();

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,6 +20,7 @@ test_sources = files(
     'web_test.vala',
     'system-path-test.vala',
     'systemd-timer-test.vala',
+    'migration-v0.6.6-test.vala',
     'faugus-launcher-test.vala',
     'metadata_test.vala',
     'compatibility-tool-test.vala',

--- a/tests/migration-v0.6.6-test.vala
+++ b/tests/migration-v0.6.6-test.vala
@@ -1,0 +1,85 @@
+namespace AppTests.MigrationV0_6_6Test {
+    using GLib;
+    using ProtonPlus.Services.Migrations.Versions;
+
+    public void register_tests () {
+        Test.add_func ("/migrations/v0.6.6/removes-legacy-flatpak-systemd-units", test_removes_legacy_flatpak_systemd_units);
+        Test.add_func ("/migrations/v0.6.6/native-install-does-not-remove-units", test_native_install_does_not_remove_units);
+    }
+
+    private string temporary_directory () {
+        try {
+            return DirUtils.make_tmp ("protonplus-migration-v0.6.6-test-XXXXXX");
+        } catch (FileError e) {
+            critical ("Could not create temporary directory: %s", e.message);
+            assert_not_reached ();
+        }
+    }
+
+    private void create_file (string path) {
+        try {
+            var parent = File.new_for_path (Path.get_dirname (path));
+            if (!parent.query_exists ())
+                parent.make_directory_with_parents ();
+            FileUtils.set_contents (path, "fixture\n");
+        } catch (Error e) {
+            critical ("Could not create fixture: %s", e.message);
+            assert_not_reached ();
+        }
+    }
+
+    private void remove_fixture (string root) {
+        var systemd_dir = Path.build_filename (root, "systemd", "user");
+        foreach (var name in new string[] {
+            "protonplus.service",
+            "protonplus.timer",
+            "other.service"
+        }) {
+            var path = Path.build_filename (systemd_dir, name);
+            if (FileUtils.test (path, FileTest.EXISTS))
+                assert (FileUtils.remove (path) == 0);
+        }
+
+        if (FileUtils.test (systemd_dir, FileTest.IS_DIR))
+            assert (DirUtils.remove (systemd_dir) == 0);
+        var systemd_parent = Path.build_filename (root, "systemd");
+        if (FileUtils.test (systemd_parent, FileTest.IS_DIR))
+            assert (DirUtils.remove (systemd_parent) == 0);
+        assert (DirUtils.remove (root) == 0);
+    }
+
+    private void test_removes_legacy_flatpak_systemd_units () {
+        var root = temporary_directory ();
+        var systemd_dir = Path.build_filename (root, "systemd", "user");
+        var service_path = Path.build_filename (systemd_dir, "protonplus.service");
+        var timer_path = Path.build_filename (systemd_dir, "protonplus.timer");
+        var unrelated_path = Path.build_filename (systemd_dir, "other.service");
+
+        create_file (service_path);
+        create_file (timer_path);
+        create_file (unrelated_path);
+
+        v0_6_6.cleanup_legacy_flatpak_systemd_units (true, root);
+
+        assert (!FileUtils.test (service_path, FileTest.EXISTS));
+        assert (!FileUtils.test (timer_path, FileTest.EXISTS));
+        assert (FileUtils.test (unrelated_path, FileTest.EXISTS));
+        remove_fixture (root);
+    }
+
+    private void test_native_install_does_not_remove_units () {
+        var root = temporary_directory ();
+        var systemd_dir = Path.build_filename (root, "systemd", "user");
+        var service_path = Path.build_filename (systemd_dir, "protonplus.service");
+        var timer_path = Path.build_filename (systemd_dir, "protonplus.timer");
+
+        create_file (service_path);
+        create_file (timer_path);
+
+        v0_6_6.cleanup_legacy_flatpak_systemd_units (false, root);
+
+        assert (FileUtils.test (service_path, FileTest.EXISTS));
+        assert (FileUtils.test (timer_path, FileTest.EXISTS));
+        remove_fixture (root);
+    }
+}

--- a/tests/migration-v0.6.6-test.vala
+++ b/tests/migration-v0.6.6-test.vala
@@ -4,6 +4,7 @@ namespace AppTests.MigrationV0_6_6Test {
 
     public void register_tests () {
         Test.add_func ("/migrations/v0.6.6/removes-legacy-flatpak-systemd-units", test_removes_legacy_flatpak_systemd_units);
+        Test.add_func ("/migrations/v0.6.6/removes-empty-legacy-flatpak-systemd-directories", test_removes_empty_legacy_flatpak_systemd_directories);
         Test.add_func ("/migrations/v0.6.6/native-install-does-not-remove-units", test_native_install_does_not_remove_units);
     }
 
@@ -64,7 +65,27 @@ namespace AppTests.MigrationV0_6_6Test {
         assert (!FileUtils.test (service_path, FileTest.EXISTS));
         assert (!FileUtils.test (timer_path, FileTest.EXISTS));
         assert (FileUtils.test (unrelated_path, FileTest.EXISTS));
+        assert (FileUtils.test (systemd_dir, FileTest.IS_DIR));
         remove_fixture (root);
+    }
+
+    private void test_removes_empty_legacy_flatpak_systemd_directories () {
+        var root = temporary_directory ();
+        var systemd_parent = Path.build_filename (root, "systemd");
+        var systemd_dir = Path.build_filename (systemd_parent, "user");
+        var service_path = Path.build_filename (systemd_dir, "protonplus.service");
+        var timer_path = Path.build_filename (systemd_dir, "protonplus.timer");
+
+        create_file (service_path);
+        create_file (timer_path);
+
+        v0_6_6.cleanup_legacy_flatpak_systemd_units (true, root);
+
+        assert (!FileUtils.test (service_path, FileTest.EXISTS));
+        assert (!FileUtils.test (timer_path, FileTest.EXISTS));
+        assert (!FileUtils.test (systemd_dir, FileTest.IS_DIR));
+        assert (!FileUtils.test (systemd_parent, FileTest.IS_DIR));
+        assert (DirUtils.remove (root) == 0);
     }
 
     private void test_native_install_does_not_remove_units () {

--- a/tests/systemd-timer-test.vala
+++ b/tests/systemd-timer-test.vala
@@ -43,6 +43,9 @@ namespace AppTests.SystemdTimerTest {
     }
 
     public void register_tests () {
+        Test.add_func ("/systemd-timer/native-user-directory", test_native_user_directory);
+        Test.add_func ("/systemd-timer/flatpak-host-user-directory", test_flatpak_host_user_directory);
+        Test.add_func ("/systemd-timer/flatpak-missing-host-directory-fallback", test_flatpak_missing_host_directory_fallback);
         Test.add_func ("/systemd-timer/new-schedule-starts-immediately", test_new_schedule_starts_immediately);
         Test.add_func ("/systemd-timer/schedule-change-restarts-active-timer", test_schedule_change_restarts_active_timer);
         Test.add_func ("/systemd-timer/startup-reenables-disabled-timer", test_startup_reenables_disabled_timer);
@@ -94,6 +97,33 @@ namespace AppTests.SystemdTimerTest {
         if (FileUtils.test (timer_path, FileTest.EXISTS))
             assert (FileUtils.remove (timer_path) == 0);
         assert (DirUtils.remove (root) == 0);
+    }
+
+    private void test_native_user_directory () {
+        var path = System.get_systemd_user_dir_for_environment (
+            false,
+            "/home/test/.config",
+            null
+        );
+        assert (path == "/home/test/.config/systemd/user");
+    }
+
+    private void test_flatpak_host_user_directory () {
+        var path = System.get_systemd_user_dir_for_environment (
+            true,
+            "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
+            "/home/test/.config"
+        );
+        assert (path == "/home/test/.config/systemd/user");
+    }
+
+    private void test_flatpak_missing_host_directory_fallback () {
+        var path = System.get_systemd_user_dir_for_environment (
+            true,
+            "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
+            ""
+        );
+        assert (path == "/home/test/.var/app/com.vysp3r.ProtonPlus/config/systemd/user");
     }
 
     private void test_new_schedule_starts_immediately () {

--- a/tests/systemd-timer-test.vala
+++ b/tests/systemd-timer-test.vala
@@ -46,7 +46,6 @@ namespace AppTests.SystemdTimerTest {
         Test.add_func ("/systemd-timer/native-user-directory", test_native_user_directory);
         Test.add_func ("/systemd-timer/flatpak-host-user-directory", test_flatpak_host_user_directory);
         Test.add_func ("/systemd-timer/flatpak-missing-host-directory-fallback", test_flatpak_missing_host_directory_fallback);
-        Test.add_func ("/systemd-timer/flatpak-empty-host-directory-fallback", test_flatpak_empty_host_directory_fallback);
         Test.add_func ("/systemd-timer/new-schedule-starts-immediately", test_new_schedule_starts_immediately);
         Test.add_func ("/systemd-timer/schedule-change-restarts-active-timer", test_schedule_change_restarts_active_timer);
         Test.add_func ("/systemd-timer/startup-reenables-disabled-timer", test_startup_reenables_disabled_timer);
@@ -104,7 +103,6 @@ namespace AppTests.SystemdTimerTest {
         var path = System.get_systemd_user_dir_for_environment (
             false,
             "/home/test/.config",
-            "/home/test",
             null
         );
         assert (path == "/home/test/.config/systemd/user");
@@ -114,30 +112,18 @@ namespace AppTests.SystemdTimerTest {
         var path = System.get_systemd_user_dir_for_environment (
             true,
             "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
-            "/home/test",
-            "/custom/config"
+            "/home/test/.config"
         );
-        assert (path == "/custom/config/systemd/user");
+        assert (path == "/home/test/.config/systemd/user");
     }
 
     private void test_flatpak_missing_host_directory_fallback () {
         var path = System.get_systemd_user_dir_for_environment (
             true,
             "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
-            "/home/test",
-            null
+            ""
         );
-        assert (path == "/home/test/.config/systemd/user");
-    }
-
-    private void test_flatpak_empty_host_directory_fallback () {
-        var path = System.get_systemd_user_dir_for_environment (
-            true,
-            "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
-            "/home/test",
-            "   "
-        );
-        assert (path == "/home/test/.config/systemd/user");
+        assert (path == "/home/test/.var/app/com.vysp3r.ProtonPlus/config/systemd/user");
     }
 
     private void test_new_schedule_starts_immediately () {

--- a/tests/systemd-timer-test.vala
+++ b/tests/systemd-timer-test.vala
@@ -46,6 +46,7 @@ namespace AppTests.SystemdTimerTest {
         Test.add_func ("/systemd-timer/native-user-directory", test_native_user_directory);
         Test.add_func ("/systemd-timer/flatpak-host-user-directory", test_flatpak_host_user_directory);
         Test.add_func ("/systemd-timer/flatpak-missing-host-directory-fallback", test_flatpak_missing_host_directory_fallback);
+        Test.add_func ("/systemd-timer/flatpak-empty-host-directory-fallback", test_flatpak_empty_host_directory_fallback);
         Test.add_func ("/systemd-timer/new-schedule-starts-immediately", test_new_schedule_starts_immediately);
         Test.add_func ("/systemd-timer/schedule-change-restarts-active-timer", test_schedule_change_restarts_active_timer);
         Test.add_func ("/systemd-timer/startup-reenables-disabled-timer", test_startup_reenables_disabled_timer);
@@ -103,6 +104,7 @@ namespace AppTests.SystemdTimerTest {
         var path = System.get_systemd_user_dir_for_environment (
             false,
             "/home/test/.config",
+            "/home/test",
             null
         );
         assert (path == "/home/test/.config/systemd/user");
@@ -112,18 +114,30 @@ namespace AppTests.SystemdTimerTest {
         var path = System.get_systemd_user_dir_for_environment (
             true,
             "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
-            "/home/test/.config"
+            "/home/test",
+            "/custom/config"
         );
-        assert (path == "/home/test/.config/systemd/user");
+        assert (path == "/custom/config/systemd/user");
     }
 
     private void test_flatpak_missing_host_directory_fallback () {
         var path = System.get_systemd_user_dir_for_environment (
             true,
             "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
-            ""
+            "/home/test",
+            null
         );
-        assert (path == "/home/test/.var/app/com.vysp3r.ProtonPlus/config/systemd/user");
+        assert (path == "/home/test/.config/systemd/user");
+    }
+
+    private void test_flatpak_empty_host_directory_fallback () {
+        var path = System.get_systemd_user_dir_for_environment (
+            true,
+            "/home/test/.var/app/com.vysp3r.ProtonPlus/config",
+            "/home/test",
+            "   "
+        );
+        assert (path == "/home/test/.config/systemd/user");
     }
 
     private void test_new_schedule_starts_immediately () {


### PR DESCRIPTION
Fixes #1269

## Summary
- write systemd user units to the host XDG config directory when running as a Flatpak
- preserve native behavior and use the XDG default `$HOME/.config` when `HOST_XDG_CONFIG_HOME` is unavailable or empty
- add a v0.6.6 migration that removes the two stale ProtonPlus systemd units previously written inside the Flatpak sandbox
- remove the legacy sandbox `systemd/user` and `systemd` directories when they are empty, while preserving them if unrelated files are present
- add regression coverage for native and Flatpak systemd unit paths and migration cleanup behavior
- bump ProtonPlus to 0.6.6 and update the Flatpak manifest
- add 0.6.6 AppStream release notes, including the latest Spanish localization update

## Details
Flatpak redirects the application's XDG config directory into its sandbox, while ProtonPlus executes `systemctl --user` on the host. The generated service and timer therefore ended up in a directory the host systemd user manager does not search.

This change uses `HOST_XDG_CONFIG_HOME` for the systemd user-unit directory when Flatpak exposes it. If the host does not set `XDG_CONFIG_HOME` and therefore no `HOST_XDG_CONFIG_HOME` is provided, ProtonPlus now supplies the XDG-specified default of `$HOME/.config` before systemd reconciliation. This avoids falling back to the sandbox config directory.

For users upgrading from 0.6.5, the v0.6.6 migration removes the orphaned sandbox copies of `protonplus.service` and `protonplus.timer`. It then removes the legacy `systemd/user` and `systemd` directories only when they are empty. Unrelated files and directories are left untouched.