### PR TITLE
docs: add Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
   <a href="https://github.com/Vysp3r/ProtonPlus/releases">Releases</a>
   ·
   <a href="https://github.com/Vysp3r/ProtonPlus/issues">Issue tracker</a>
+  ·
+  <a href="https://discord.gg/qNRPQvC7m4">Discord</a>
 </p>
 
 ProtonPlus helps you install, update, remove, and organize compatibility tools used by Steam and other Linux game launchers. It discovers supported launcher installations, downloads releases from their upstream sources, and installs them into the layouts expected by each launcher.

--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -88,6 +88,13 @@
   </screenshots>
 
   <releases>
+    <release version="0.6.8" date="2026-09-08">
+      <description>
+        <ul>
+          <li>✨ Added a Discord community link to the About dialog</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.7" date="2026-09-08">
       <description>
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'com.vysp3r.ProtonPlus',
     ['c', 'vala'],
-    version: '0.6.7',
+    version: '0.6.8',
     meson_version: '>= 1.0.0',
     default_options: [
         'warning_level=2',

--- a/src/widgets/application.vala
+++ b/src/widgets/application.vala
@@ -241,6 +241,7 @@ namespace ProtonPlus.Widgets {
             about_dialog.set_comments (_("A modern compatibility tools manager"));
             about_dialog.add_link ("GitHub", "https://github.com/Vysp3r/ProtonPlus");
             about_dialog.add_link (_("Website"), "https://protonplus.vysp3r.com/");
+            about_dialog.add_link (_("Discord"), "https://discord.gg/qNRPQvC7m4");
             about_dialog.set_issue_url ("https://github.com/Vysp3r/ProtonPlus/issues/new/choose");
             about_dialog.set_copyright (get_copyright ());
             about_dialog.set_license_type (Gtk.License.GPL_3_0);


### PR DESCRIPTION
## Summary
- Add the ProtonPlus Discord invite to the README's primary project links.
- Add a Discord link to the in-app About dialog.

## Link
- https://discord.gg/qNRPQvC7m4

This is a small documentation/UI-link change.