### PR TITLE
website: add Discord link and refresh project information

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         <div class="hero">
             <img src="https://raw.githubusercontent.com/Vysp3r/ProtonPlus/refs/heads/main/data/icons/com.vysp3r.ProtonPlus.svg" alt="ProtonPlus Logo" class="logo">
             <h1>ProtonPlus</h1>
-            <p class="release-kicker">Version 0.6.0</p>
+            <p class="release-kicker">Version 0.6.7</p>
         </div>
 
         <div class="badges">
@@ -104,68 +104,60 @@
                 <a class="button button-primary" href="#download">Download ProtonPlus</a>
                 <a class="button button-secondary" href="https://github.com/Vysp3r/ProtonPlus" target="_blank"
                     rel="noopener noreferrer">View on GitHub</a>
+                <a class="button button-secondary" href="https://discord.gg/qNRPQvC7m4" target="_blank"
+                    rel="noopener noreferrer">Join Discord</a>
             </div>
         </section>
 
         <section class="whats-new" id="whats-new">
-            <h2>What's New Since v0.5.22</h2>
+            <h2>What's New in v0.6.7</h2>
             <p class="section-intro">
-                Version 0.6.0 expands ProtonPlus well beyond tool installation, with new ways to manage games,
-                updates, hardware-specific releases, and the app itself.
+                ProtonPlus 0.6.7 continues the 0.6 series with compatibility fixes, provider cleanup, and localization updates.
             </p>
 
             <div class="release-grid">
                 <article class="release-card">
-                    <h3>New Capabilities</h3>
+                    <h3>Compatibility</h3>
+                    <ul>
+                        <li>Fixed Proton-Wineland WoW64 releases not being detected</li>
+                        <li>Renamed Proton-CachyOS Wineland to Proton-Wineland</li>
+                    </ul>
+                </article>
+
+                <article class="release-card">
+                    <h3>Recent 0.6.x Improvements</h3>
+                    <ul>
+                        <li>Fixed scheduled tool updates under Flatpak</li>
+                        <li>Improved release-catalog refresh behavior</li>
+                        <li>Improved adaptive layouts, Games sorting, controller navigation, and theme compatibility</li>
+                        <li>Improved safeguards around tools that are currently in use</li>
+                    </ul>
+                </article>
+
+                <article class="release-card">
+                    <h3>0.6 Series Highlights</h3>
                     <ul>
                         <li>Faugus Launcher support</li>
                         <li>CPU-aware x86-64 and ARM64 variant selection</li>
                         <li>Scheduled background updates and notifications</li>
-                        <li>Gamepad navigation, contextual hints, optional haptics, and a first-run guide</li>
-                        <li>Breeze Light, Breeze Dark, SteamOS, and OLED themes</li>
-                        <li>A built-in MangoHud editor and proxy settings</li>
-                        <li>Steam shortcut creation and guided restarts, including SteamOS Gaming Mode</li>
-                        <li>Default Steam compatibility prefix migration</li>
-                        <li>An active downloads indicator</li>
-                        <li>ARM64 Flatpak support</li>
-                    </ul>
-                </article>
-
-                <article class="release-card">
-                    <h3>Games & Launch Options</h3>
-                    <ul>
-                        <li>A redesigned, hardware-aware launch options editor with exact command previews</li>
-                        <li>Custom and unknown safe options stay intact during single-game and mass edits</li>
-                        <li>Improved Games and Tools navigation, search, filtering, selection, and repository links</li>
-                        <li>Improved stable-release, Latest, and variant selection</li>
-                    </ul>
-                </article>
-
-                <article class="release-card">
-                    <h3>Reliability & Compatibility</h3>
-                    <ul>
-                        <li>Safer downloads and updates with timeout recovery, archive checks, preserved settings, and rollback</li>
-                        <li>Improved Steam multi-user, VDF, and shortcut handling</li>
-                        <li>Clearer command-line validation and error reporting</li>
-                        <li>Fixed custom executable launches and kept the app usable when some Steam data cannot load</li>
-                        <li>Fixed release and installation issues for Proton-TKG, Proton-CachyOS, DXVK, VKD3D, Lutris, and Steam Tinker Launch</li>
+                        <li>Gamepad navigation with contextual hints and optional haptics</li>
+                        <li>Breeze, SteamOS, and OLED themes</li>
+                        <li>Built-in MangoHud configuration</li>
                     </ul>
                 </article>
 
                 <article class="release-card">
                     <h3>Localization</h3>
                     <ul>
-                        <li>Added Arabic</li>
-                        <li>Added Slovak</li>
-                        <li>Updated Simplified Chinese</li>
-                        <li>Updated German</li>
-                        <li>Updated Italian</li>
+                        <li>Updated Polish</li>
+                        <li>Updated Russian</li>
+                        <li>Updated Spanish</li>
                     </ul>
                 </article>
             </div>
 
-            <a class="release-link" href="https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.0" target="_blank"
-                rel="noopener noreferrer">View the v0.6.0 release on GitHub</a>
+            <a class="release-link" href="https://github.com/Vysp3r/ProtonPlus/releases/tag/v0.6.7" target="_blank"
+                rel="noopener noreferrer">View the v0.6.7 release on GitHub</a>
         </section>
 
         <section class="screenshots" id="screenshots">
@@ -266,7 +258,7 @@
                                 <li>Proton-GE</li>
                                 <li>Proton-GE RTSP</li>
                                 <li>Proton-CachyOS</li>
-                                <li>Proton-CachyOS Wineland</li>
+                                <li>Proton-Wineland</li>
                                 <li>DW-Proton</li>
                                 <li>Proton-EM</li>
                                 <li>Proton-Tkg</li>
@@ -360,6 +352,7 @@
             <h2>Links</h2>
 
             <div class="links-container">
+                <a href="https://discord.gg/qNRPQvC7m4" target="_blank" rel="noopener noreferrer">Discord community</a>
                 <a href="https://github.com/Vysp3r/ProtonPlus/issues/new?template=bug_report.md">Report an issue</a>
                 <a href="https://github.com/Vysp3r/ProtonPlus/issues/new?template=feature_request.md">Request a feature</a>
                 <a href="https://hosted.weblate.org/projects/protonplus/protonplus/">Help translate</a>


### PR DESCRIPTION
## Summary
- Add the ProtonPlus Discord invite to the website hero actions and Links section.
- Update the website from v0.6.0 to the current released version, v0.6.7.
- Refresh the What's New section with current 0.6.x information.
- Rename Proton-CachyOS Wineland to Proton-Wineland in the supported tools list.

## Discord
- https://discord.gg/qNRPQvC7m4

This PR targets the `website` branch and keeps unreleased v0.6.8 information off the public site.