### PR TITLE
Fix changelog rendering with emphasis characters in code

### DIFF
--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -92,6 +92,7 @@
       <description>
         <ul>
           <li>✨ Added a Discord community link to the About dialog</li>
+          <li>🐛 Fixed some release changelogs failing to render when inline code contains Markdown emphasis characters</li>
         </ul>
       </description>
     </release>

--- a/src/widgets/tools/tools-release-changelog.vala
+++ b/src/widgets/tools/tools-release-changelog.vala
@@ -137,17 +137,34 @@ namespace ProtonPlus.Widgets.Tools {
             }
         }
 
+        private string protect_code_emphasis (string code) {
+            return code
+                .replace ("*", "&#42;")
+                .replace ("_", "&#95;")
+                .replace ("~", "&#126;");
+        }
+
         private string markdown_to_markup (string markdown) {
             string text = Markup.escape_text (markdown);
 
             try {
             // Code blocks: ```code``` -> <tt>code</tt>
                 var code_block = new Regex ("```(?:[a-zA-Z0-9]*\n)?([\\s\\S]*?)```", RegexCompileFlags.MULTILINE);
-                text = code_block.replace (text, -1, 0, "<tt>\\1</tt>");
+                text = code_block.replace_eval (text, -1, 0, 0, (match_info, result) => {
+                    result.append ("<tt>");
+                    result.append (protect_code_emphasis (match_info.fetch (1)));
+                    result.append ("</tt>");
+                    return false;
+                });
 
             // Inline code: `code` -> <tt>code</tt>
                 var code = new Regex ("`(.*?)`", RegexCompileFlags.MULTILINE);
-                text = code.replace (text, -1, 0, "<tt>\\1</tt>");
+                text = code.replace_eval (text, -1, 0, 0, (match_info, result) => {
+                    result.append ("<tt>");
+                    result.append (protect_code_emphasis (match_info.fetch (1)));
+                    result.append ("</tt>");
+                    return false;
+                });
 
             // Headers: # Title -> <b><span size="x-large">Title</span></b>
                 var header1 = new Regex ("^# (.*)$", RegexCompileFlags.MULTILINE);


### PR DESCRIPTION
## Summary

- protect emphasis characters inside changelog code spans and code blocks from later Markdown parsing
- prevent invalid Pango markup when multiple inline code spans contain `*`, `_`, or `~`
- update AppStream metainfo for the fix

## Context

Proton-Wineland's newer release notes contain inline code such as `wineland-*` and `proton-wineland-*`. The changelog renderer converted the code spans to `<tt>` first, then the generic emphasis regex interpreted the asterisks across those spans as italic markup. That produced invalid nested Pango markup and caused the changelog to render blank.

This keeps code contents visually unchanged while encoding emphasis metacharacters before the remaining Markdown substitutions run.

Fixes #1288