### PR TITLE
Fix Steam restart notification icon

### DIFF
--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -514,7 +514,6 @@
           <li>✨ Added the ability to manage launch options of games</li>
           <li>✨ Added a way to open the install/prefix directory of games</li>
           <li>✨ Added the ability to set the default compatibility tool for Steam games</li>
-          <li>✨ Added the ability to change the compatibility tool of Steam games</li>
           <li>🌐 Updated Chinese localization</li>
           <li>🌐 Updated German localization</li>
           <li>🌐 Updated Portuguese localization</li>
@@ -627,7 +626,6 @@
         <ul>
           <li>🐛 Fix HGL support</li>
           <li>🌐 Updated German translation</li>
-          <li>🌐 Updated Czech translation</li>
         </ul>
       </description>
     </release>

--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -93,6 +93,8 @@
         <ul>
           <li>✨ Added a Discord community link to the About dialog</li>
           <li>🐛 Fixed some release changelogs failing to render when inline code contains Markdown emphasis characters</li>
+          <li>🐛 Fixed the Steam restart notification missing its icon</li>
+          <li>🌐 Updated Polish localization</li>
         </ul>
       </description>
     </release>
@@ -512,6 +514,7 @@
           <li>✨ Added the ability to manage launch options of games</li>
           <li>✨ Added a way to open the install/prefix directory of games</li>
           <li>✨ Added the ability to set the default compatibility tool for Steam games</li>
+          <li>✨ Added the ability to change the compatibility tool of Steam games</li>
           <li>🌐 Updated Chinese localization</li>
           <li>🌐 Updated German localization</li>
           <li>🌐 Updated Portuguese localization</li>
@@ -624,6 +627,7 @@
         <ul>
           <li>🐛 Fix HGL support</li>
           <li>🌐 Updated German translation</li>
+          <li>🌐 Updated Czech translation</li>
         </ul>
       </description>
     </release>

--- a/src/widgets/main/steam-restart-presentation.vala
+++ b/src/widgets/main/steam-restart-presentation.vala
@@ -216,8 +216,10 @@ namespace ProtonPlus.Widgets.Main {
 
     public class LibnotifySteamRestartNotificationSender : Object, SteamRestartNotificationSender {
         public void send_restart_required (string message) throws Error {
-            var notification = new Notify.Notification (_ ("Steam restart needed"), message, "steam-symbolic");
+            var notification = new Notify.Notification (_ ("Steam restart needed"), message, null);
             try {
+                var icon = new Gdk.Pixbuf.from_resource ("%s/steam.svg".printf (Config.RESOURCE_BASE));
+                notification.set_image_from_pixbuf (icon);
                 notification.show ();
             } catch (Error e) {
                 throw new SteamRestartNotificationError.DELIVERY_FAILED ("%s", e.message);


### PR DESCRIPTION
## Summary
- use ProtonPlus' bundled Steam icon for Steam restart notifications instead of relying on the host `steam-symbolic` icon theme
- update the 0.6.8 metainfo release notes with the notification icon fix
- include the newly merged Polish localization update in the 0.6.8 metainfo

This keeps the notification icon consistent with the Steam artwork already shipped by ProtonPlus and avoids host icon-theme differences under Flatpak.

Fixes #1234