### PR TITLE
i18n: use ngettext for the mass-edit selection label, fix OLE Moniker…

### DIFF
--- a/src/widgets/games/games-mass-edit-view.vala
+++ b/src/widgets/games/games-mass-edit-view.vala
@@ -24,7 +24,7 @@ namespace ProtonPlus.Widgets.Games {
         ulong header_back_handler = 0;
 
         public string get_selection_text () {
-            return items.length == 1 ? _("1 game selected") : _("%u games selected").printf (items.length);
+            return ngettext ("%u game selected", "%u games selected", items.length).printf (items.length);
         }
 
         public MassEditView (Gtk.MenuButton selection_button) {

--- a/src/widgets/games/launch-options-editor/groups/dxvk-options-group.vala
+++ b/src/widgets/games/launch-options-editor/groups/dxvk-options-group.vala
@@ -27,7 +27,7 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor.Groups {
                                                     { "DXVK_LOG_LEVEL=none" }, false, LaunchLineType.ENVIRONMENT, "dxvk-log-level");
 
             dxvk_frame_rate_tile = create_spin_tile (
-                                                     _("DXVK Frame Limit"),
+                                                     _("DXVK frame limit"),
                                                      _("Caps the frame rate using DXVK's built-in frame limiter."),
                                                      _("FPS"),
                                                      0,

--- a/src/widgets/games/launch-options-editor/launch-options-editor-dll-overrides.vala
+++ b/src/widgets/games/launch-options-editor/launch-options-editor-dll-overrides.vala
@@ -60,7 +60,7 @@ using Gtk;
             tooltips.insert ("openal32", _ ("OpenAL 3D Audio library (enables hardware sound acceleration)"));
             tooltips.insert ("dinput8", _ ("DirectInput 8 (commonly used to inject scripts/ASI mod loaders)"));
             tooltips.insert ("winhttp", _ ("Windows Internet HTTP API (fixes network connectivity in launchers)"));
-            tooltips.insert ("urlmon", _ ("OLE Monkers library for URL handling and launcher updates"));
+            tooltips.insert ("urlmon", _ ("OLE Monikers library for URL handling and launcher updates"));
             tooltips.insert ("wininet", _ ("Windows Internet API layer (fixes online features in game launchers)"));
             tooltips.insert ("binkw32", _ ("Bink Video 32-bit decoder (fixes intro movie crashes)"));
             tooltips.insert ("bink2w64", _ ("Bink Video 64-bit decoder (fixes intro movie crashes in modern games)"));

--- a/src/widgets/mangohud/mangohud-metrics-page.vala
+++ b/src/widgets/mangohud/mangohud-metrics-page.vala
@@ -117,7 +117,7 @@ namespace ProtonPlus.Widgets.MangoHud {
             });
 
             gpu_name_row = create_switch (_ ("Model"), config.gpu_name, (val) => { this.config.gpu_name = val; });
-            vulkan_driver_row = create_switch (_ ("Vulkan Driver"), config.vulkan_driver, (val) => { this.config.vulkan_driver = val; });
+            vulkan_driver_row = create_switch (_ ("Vulkan driver"), config.vulkan_driver, (val) => { this.config.vulkan_driver = val; });
             gpu_procs_row = create_switch (_ ("Process"), config.procs, (val) => { this.config.procs = val; });
 
             add_flow_group (gpu_metrics_box, _ ("Information"), {


### PR DESCRIPTION
### Category

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation
- [ ] Translation
- [ ] Other (Please specify!)

### Overview

Four small i18n fixes found while taking the Polish catalogue from 10% to 100% on Weblate.

**1. `games-mass-edit-view.vala` — selection label now uses `ngettext`**

```diff
-return items.length == 1 ? _("1 game selected") : _("%u games selected").printf (items.length);
+return ngettext ("%u game selected", "%u games selected", items.length).printf (items.length);
```

The old form assumes a language has two plural categories. Polish has three (1 / 2-4 / 5+), so the single "%u games selected" string had to cover both "2 gry" and "5 gier" — different words, and no translation is correct for both.

The effect is visible in the current release: the Polish UI is correct with one game selected, but reads "Zaznaczono 3 gier" with three, where correct Polish is "Zaznaczono 3 gry" — 3 takes the same form as 2, not the same as 5. Russian, Czech, Croatian, Ukrainian, Serbian and Slovak hit the same wall, so roughly a third of the languages on Weblate are affected.

`tools-migrate-box.vala:58` already solves the identical case with `ngettext`, so this mirrors the existing pattern rather than introducing a new one.

One consequence worth flagging: this replaces two source strings with a single plural entry, so "1 game selected" and "%u games selected" will need re-translating in every language.

**2. `launch-options-editor-dll-overrides.vala` — typo**

"OLE Monkers library for URL handling and launcher updates" → "OLE Monikers". The tooltip describes `urlmon`;

**3-4. Two strings deduplicated, differing only in capitalisation**

- "DXVK Frame Limit" → "DXVK frame limit" (`groups/dxvk-options-group.vala:30`), matching `launch-options-option-catalog.vala:1275`
- "Vulkan Driver" → "Vulkan driver" (`mangohud/mangohud-metrics-page.vala:120`), matching `launch-options-option-catalog.vala:1298`

Both pairs were separate msgids, so every language translated each label twice. I kept the catalogue's lower-case variant, since the catalogue holds most of the options.

**Deliberately left out.** Two more things turned up in the same review, but both are judgement calls rather than clear defects:


### Issue Number

### New Variables or Dependencies

### How to Test

```
./scripts/build.sh native
meson test -C build-native --print-errorlogs   # 5/5 targets OK, 529 subtests passed
git diff --check                               # clean
```

Built and run natively on Fedora (valac 0.56.19, GTK 4.22.4, libadwaita 1.9.3).

To verify the plural fix: select one game, open mass edit and note the label, then repeat with three. With the patch the label switches between the singular and plural source strings as the count changes. Both render untranslated for now, which is expected — the new plural entry only reaches Weblate once this lands.

### Screenshots (if applicable)

No UI changes — only the string passed to the label. The user-visible difference is grammatical: in the current release the Polish UI reads "Zaznaczono 3 gier" for three selected games, where correct Polish is "Zaznaczono 3 gry".

### Checklist

- [x] My code follows the project's [style guide](https://github.com/Vysp3r/ProtonPlus/blob/main/CONTRIBUTING.md#style-guide).
- [x] I have tested my changes and verified that they work as expected.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have updated the translations by running `./scripts/build.sh translations` (if applicable).
- [x] I have checked for existing pull requests that cover these changes.

On the translations checkbox: I left `po/` untouched on purpose. Running the target locally rewrites entry order and line references across all 26 catalogues (~5,500 changed lines for 4 changed strings) and would collide with the open Weblate PRs. Regenerating after this merges, or letting Weblate pick the new plural entry up, seems cleaner.