### PR TITLE
Fix Steam library loading with modern libraryfolders.vdf path

### DIFF
--- a/data/com.vysp3r.ProtonPlus.metainfo.xml.in
+++ b/data/com.vysp3r.ProtonPlus.metainfo.xml.in
@@ -88,6 +88,14 @@
   </screenshots>
 
   <releases>
+    <release version="0.6.9" date="2026-09-12">
+      <description>
+        <ul>
+          <li>🐛 Fixed Steam games not loading when Steam stores libraryfolders.vdf in the config directory</li>
+          <li>🌐 Updated Ukrainian localization</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.8" date="2026-09-08">
       <description>
         <ul>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'com.vysp3r.ProtonPlus',
     ['c', 'vala'],
-    version: '0.6.8',
+    version: '0.6.9',
     meson_version: '>= 1.0.0',
     default_options: [
         'warning_level=2',

--- a/src/models/launchers/steam.vala
+++ b/src/models/launchers/steam.vala
@@ -207,13 +207,41 @@ namespace ProtonPlus.Models.Launchers {
             if (default_compatibility_tool != null)
             this.default_compatibility_tool = default_compatibility_tool;
 
-            var libraryfolder_content = yield Utils.Filesystem.get_file_content_async ("%s/steamapps/libraryfolders.vdf".printf (directory));
+            Utils.VDF.VdfDocument? libraryfolder_document = null;
+            var libraryfolder_path = "";
+            var libraryfolder_candidates = new string[] {
+                Path.build_filename (directory, "config", "libraryfolders.vdf"),
+                Path.build_filename (directory, "steamapps", "libraryfolders.vdf"),
+            };
 
-            var libraryfolder_document = Utils.VDF.VdfParser.parse_document (libraryfolder_content);
-            if (libraryfolder_document == null)
+            foreach (var candidate in libraryfolder_candidates) {
+                if (!FileUtils.test (candidate, FileTest.IS_REGULAR))
+                    continue;
+
+                var libraryfolder_content = yield Utils.Filesystem.get_file_content_async (candidate);
+                var candidate_document = Utils.VDF.VdfParser.parse_document (libraryfolder_content);
+                if (candidate_document == null) {
+                    warning ("Could not parse Steam library folders file: %s", candidate);
+                    continue;
+                }
+
+                if (((!) candidate_document).root.get_child ("libraryfolders") == null) {
+                    warning ("Steam library folders file has no libraryfolders root: %s", candidate);
+                    continue;
+                }
+
+                libraryfolder_document = (!) candidate_document;
+                libraryfolder_path = candidate;
+                break;
+            }
+
+            if (libraryfolder_document == null) {
+                warning ("Could not find a valid Steam library folders file below: %s", directory);
                 return false;
+            }
 
-            var libraryfolders = libraryfolder_document.root.get_child ("libraryfolders");
+            debug ("Loading Steam library folders from: %s", libraryfolder_path);
+            var libraryfolders = ((!) libraryfolder_document).root.get_child ("libraryfolders");
             if (libraryfolders == null)
                 return false;
 

--- a/src/models/launchers/steam.vala
+++ b/src/models/launchers/steam.vala
@@ -221,12 +221,12 @@ namespace ProtonPlus.Models.Launchers {
                 var libraryfolder_content = yield Utils.Filesystem.get_file_content_async (candidate);
                 var candidate_document = Utils.VDF.VdfParser.parse_document (libraryfolder_content);
                 if (candidate_document == null) {
-                    warning ("Could not parse Steam library folders file: %s", candidate);
+                    debug ("Could not parse Steam library folders candidate: %s", candidate);
                     continue;
                 }
 
                 if (((!) candidate_document).root.get_child ("libraryfolders") == null) {
-                    warning ("Steam library folders file has no libraryfolders root: %s", candidate);
+                    debug ("Steam library folders candidate has no libraryfolders root: %s", candidate);
                     continue;
                 }
 

--- a/tests/steam_test.vala
+++ b/tests/steam_test.vala
@@ -459,7 +459,7 @@ namespace AppTests.SteamTest {
             "\"InstallConfigStore\" { \"Software\" { \"Valve\" { \"Steam\" { } } } }"
         ));
         assert (ProtonPlus.Utils.Filesystem.modify_file (
-            Path.build_filename (steamapps_directory, "libraryfolders.vdf"),
+            Path.build_filename (config_directory, "libraryfolders.vdf"),
             "\"libraryfolders\" { \"0\" { \"path\" \"%s\" \"apps\" { \"42\" \"1\" \"43\" \"1\" } } }".printf (root)
         ));
         assert (ProtonPlus.Utils.Filesystem.modify_file (
@@ -536,6 +536,10 @@ namespace AppTests.SteamTest {
         assert (ProtonPlus.Utils.Filesystem.modify_file (
             Path.build_filename (config_directory, "config.vdf"),
             "\"InstallConfigStore\" { \"Software\" { \"Valve\" { \"Steam\" { } } } }"
+        ));
+        assert (ProtonPlus.Utils.Filesystem.modify_file (
+            Path.build_filename (config_directory, "libraryfolders.vdf"),
+            "not VDF"
         ));
         assert (ProtonPlus.Utils.Filesystem.modify_file (
             Path.build_filename (steamapps_directory, "libraryfolders.vdf"),


### PR DESCRIPTION
## Summary

Fixes #1296.

Steam can store `libraryfolders.vdf` under `config/` instead of the legacy `steamapps/` location. ProtonPlus previously only checked the legacy path, causing the Games view to fail to load on affected installations.

## Changes

- Prefer `<Steam root>/config/libraryfolders.vdf`
- Fall back to `<Steam root>/steamapps/libraryfolders.vdf` for older installations
- Skip malformed/invalid candidates and continue to the fallback
- Add diagnostics identifying invalid and selected library-folder files
- Add regression coverage for:
  - modern `config/libraryfolders.vdf` layout
  - malformed modern file with valid legacy fallback
- Bump version to **0.6.9**
- Add the 0.6.9 AppStream release entry

## Testing

The existing Steam integration tests were updated to exercise both supported layouts.