### PR TITLE
Fix RADV launch option validation

### DIFF
--- a/src/widgets/games/games-mass-edit-view.vala
+++ b/src/widgets/games/games-mass-edit-view.vala
@@ -314,7 +314,9 @@ namespace ProtonPlus.Widgets.Games {
                     if (!launch_write.writing_allowed) {
                         var detail = launch_write.writer_diagnostics.size > 0
                             ? launch_write.writer_diagnostics[0]
-                            : _("The selected launch options are incomplete or unsupported for these games.");
+                            : launch_write.composition_diagnostics.size > 0
+                                ? launch_write.composition_diagnostics[0].message
+                                : _("The selected launch options are incomplete or unsupported for these games.");
                         var dialog = new Main.ErrorDialog (_("Launch options cannot be applied"),
                             _("No games were changed because the launch command could not be prepared safely."), detail);
                         ProtonPlus.Widgets.Window.present_dialog_for_controller (dialog, (Gtk.Window) this.get_root ());

--- a/src/widgets/games/games-mass-edit-view.vala
+++ b/src/widgets/games/games-mass-edit-view.vala
@@ -312,11 +312,13 @@ namespace ProtonPlus.Widgets.Games {
                     var launch_write = launch_options_editor.prepare_write_for_source (
                         steam_game.launch_options ?? "");
                     if (!launch_write.writing_allowed) {
-                        var detail = launch_write.writer_diagnostics.size > 0
-                            ? launch_write.writer_diagnostics[0]
-                            : launch_write.composition_diagnostics.size > 0
-                                ? launch_write.composition_diagnostics[0].message
-                                : _("The selected launch options are incomplete or unsupported for these games.");
+                        string detail;
+                        if (launch_write.writer_diagnostics.size > 0)
+                            detail = launch_write.writer_diagnostics[0];
+                        else if (launch_write.composition_diagnostics.size > 0)
+                            detail = launch_write.composition_diagnostics[0].message;
+                        else
+                            detail = _("The selected launch options are incomplete or unsupported for these games.");
                         var dialog = new Main.ErrorDialog (_("Launch options cannot be applied"),
                             _("No games were changed because the launch command could not be prepared safely."), detail);
                         ProtonPlus.Widgets.Window.present_dialog_for_controller (dialog, (Gtk.Window) this.get_root ());

--- a/src/widgets/games/launch-options-editor/launch-command-composer.vala
+++ b/src/widgets/games/launch-options-editor/launch-command-composer.vala
@@ -413,11 +413,30 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                 add (diagnostics, LaunchCommandCompositionDiagnosticCode.INVALID_VALUE_COUNT, selection.option_id,
                     "Launch option '%s' requires exactly one value.".printf (selection.option_id)); return;
             }
-            bool selectable = valid_selectable (diagnostics, selection.option_id, values[0], semantics.selectable_values);
-            bool safe_value = safe (diagnostics, selection.option_id, values[0]);
+            var raw_value = values[0];
+            var selectable = true;
+            if (semantics.value_separator != "" && semantics.selectable_values.length > 0) {
+                foreach (var member in raw_value.split (semantics.value_separator)) {
+                    var clean_member = member.strip ();
+                    if (clean_member == "") {
+                        add (diagnostics, LaunchCommandCompositionDiagnosticCode.MISSING_DYNAMIC_VALUE,
+                            selection.option_id, "Launch option '%s' contains an empty value.".printf (
+                                selection.option_id));
+                        selectable = false;
+                        continue;
+                    }
+                    if (!valid_selectable (diagnostics, selection.option_id,
+                        clean_member, semantics.selectable_values))
+                        selectable = false;
+                }
+            } else {
+                selectable = valid_selectable (diagnostics, selection.option_id,
+                    raw_value, semantics.selectable_values);
+            }
+            bool safe_value = safe (diagnostics, selection.option_id, raw_value);
             if (!selectable || !safe_value) return;
             environments.add (new LaunchEnvironmentAssignment (semantics.environment_key,
-                "%s=%s".printf (semantics.environment_key, shell_word (values[0]))));
+                "%s=%s".printf (semantics.environment_key, shell_word (raw_value))));
         }
 
         void append_wrapper_argument (ArrayList<LaunchCommandCompositionDiagnostic> diagnostics,

--- a/src/widgets/games/launch-options-editor/launch-options-editor-radv-perf-test.vala
+++ b/src/widgets/games/launch-options-editor/launch-options-editor-radv-perf-test.vala
@@ -6,21 +6,26 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
 
         public LaunchOptionRadvPerftest () {
 
-            string[] keys = { "rt", "sam", "nggc", "gpl", "ruse", "emulate_rt" };
+            string[] keys = {
+                "cswave32",
+                "dccmsaa",
+                "dmashaders",
+                "gewave32",
+                "localbos",
+                "lowlatencydec",
+                "lowlatencyenc",
+                "nggc",
+                "nircache",
+                "nogttspill",
+                "nosam",
+                "pswave32",
+                "rtcps"
+            };
 
             string[] display_opts = { _ ("Disabled"), _ ("Enabled") };
             string[] value_opts = { "", "1" };
 
             var tooltips = new HashTable<string, string> (str_hash, str_equal);
-            tooltips.insert ("rt", _ ("Enables experimental hardware Ray Tracing support."));
-            tooltips.insert ("sam", _ ("Optimizes Smart Access Memory / Resizable BAR utilization."));
-            tooltips.insert ("nggc", _ ("Enables Next-Gen Geometry Culling for better geometry performance."));
-            tooltips.insert ("gpl", _ ("Graphics Pipeline Library. Drastically reduces shader stuttering."));
-            tooltips.insert ("ruse", _ ("Enables User Space Queue submission. Can improve CPU-bound game performance on modern kernels."));
-            tooltips.insert (
-                "emulate_rt",
-                _ ("Emulates hardware Ray Tracing using software compute shaders on AMD GPUs. Enables RT features on unsupported hardware at the cost of a drastic performance drop.") // vala-lint=line-length
-            );
 
             base (
                 _ ("AMD RADV Performance Tests"),

--- a/src/widgets/games/launch-options-editor/launch-options-option-catalog.vala
+++ b/src/widgets/games/launch-options-editor/launch-options-option-catalog.vala
@@ -172,6 +172,7 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
         public bool managed_emission { get; construct; }
         public string[] legacy_tokens { get; construct; }
         public string[] selectable_values { get; construct; }
+        public string value_separator { get; construct; }
         public LaunchOptionParseShape? parse_shape { get; construct; }
         LaunchOptionCapability[] _required_capabilities;
         public LaunchOptionApplicability applicability { get; construct; }
@@ -197,7 +198,8 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
             bool managed_emission = false,
             string[] legacy_tokens = {},
             string[] selectable_values = {},
-            LaunchOptionParseShape? parse_shape = null
+            LaunchOptionParseShape? parse_shape = null,
+            string value_separator = ""
         ) {
             Object (
                 kind: kind, placeholder_policy: placeholder_policy,
@@ -209,7 +211,7 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                 legacy_manual_representation: legacy_manual_representation,
                 support: support, managed_emission: managed_emission,
                 legacy_tokens: legacy_tokens, selectable_values: selectable_values,
-                parse_shape: parse_shape
+                parse_shape: parse_shape, value_separator: value_separator
             );
             this._required_capabilities = required_capabilities;
             this._composite_outputs = composite_outputs;
@@ -711,7 +713,8 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                     LaunchOptionEmissionMode.FIXED_TOKENS,
                     "", "", raw_tokens, {}, renderer_conflict_group (id), {}, {}, {},
                     LaunchOptionApplicability.GENERIC, {}, false,
-                    support_for (id), is_managed_emission (id), legacy_tokens_for (id), selectable_values_for (id)
+                    support_for (id), is_managed_emission (id), legacy_tokens_for (id), selectable_values_for (id),
+                    null, dynamic_environment_separator_for (id)
                 );
             }
             if (serialization_type == LaunchLineType.ENVIRONMENT) {
@@ -782,6 +785,18 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                     return new LaunchOptionParseShape ({ "-r" }, { 1 });
                 default:
                     return null;
+            }
+        }
+
+        string dynamic_environment_separator_for (string id) {
+            switch (id) {
+                case "vkd3d-config":
+                case "amd-radv-perftest":
+                case "amd-radv-debug":
+                case "amd-aco-debug":
+                    return ",";
+                default:
+                    return "";
             }
         }
 

--- a/src/widgets/games/launch-options-editor/launch-options-option-catalog.vala
+++ b/src/widgets/games/launch-options-editor/launch-options-option-catalog.vala
@@ -713,8 +713,7 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                     LaunchOptionEmissionMode.FIXED_TOKENS,
                     "", "", raw_tokens, {}, renderer_conflict_group (id), {}, {}, {},
                     LaunchOptionApplicability.GENERIC, {}, false,
-                    support_for (id), is_managed_emission (id), legacy_tokens_for (id), selectable_values_for (id),
-                    null, dynamic_environment_separator_for (id)
+                    support_for (id), is_managed_emission (id), legacy_tokens_for (id), selectable_values_for (id)
                 );
             }
             if (serialization_type == LaunchLineType.ENVIRONMENT) {
@@ -738,7 +737,8 @@ namespace ProtonPlus.Widgets.Games.LaunchOptionsEditor {
                     conflict_group_for (id), conflicts_for (id),
                     scopebuddy_owner (id) != "" ? backend_dependencies (dependencies) : dependencies,
                     capabilities_for (id), applicability_for (id), {}, false,
-                    support_for (id), is_managed_emission (id), legacy_tokens_for (id), selectable_values_for (id)
+                    support_for (id), is_managed_emission (id), legacy_tokens_for (id), selectable_values_for (id),
+                    null, dynamic_environment_separator_for (id)
                 );
             }
 

--- a/tests/launch-command-composer-test.vala
+++ b/tests/launch-command-composer-test.vala
@@ -8,6 +8,7 @@ namespace AppTests.LaunchCommandComposerTest {
         Test.add_func ("/launch-command-composer/wrappers-and-composite", test_wrappers_and_composite);
         Test.add_func ("/launch-command-composer/invalid-combinations", test_invalid_combinations);
         Test.add_func ("/launch-command-composer/capabilities-and-values", test_capabilities_and_values);
+        Test.add_func ("/launch-command-composer/list-valued-environment", test_list_valued_environment);
         Test.add_func ("/launch-command-composer/current-custom-proton-options", test_current_custom_proton_options);
         Test.add_func ("/launch-command-composer/current-option-conflicts", test_current_option_conflicts);
         Test.add_func ("/launch-command-composer/parsed-validation", test_parsed_validation);
@@ -152,6 +153,20 @@ namespace AppTests.LaunchCommandComposerTest {
         var bad_count = compose ({ new LaunchCommandSelection ("gamescope-resolution", { "1920" }) }, { LaunchOptionCapability.GAMESCOPE });
         assert (!bad_count.is_valid);
         assert_code (bad_count, LaunchCommandCompositionDiagnosticCode.INVALID_VALUE_COUNT);
+    }
+
+    private void test_list_valued_environment () {
+        var radv = compose ({
+            new LaunchCommandSelection ("amd-radv-perftest", { "nggc,rtcps" })
+        }, { LaunchOptionCapability.AMD });
+        assert (radv.is_valid);
+        assert (radv.launch_line == "RADV_PERFTEST=nggc,rtcps %command%");
+
+        var invalid = compose ({
+            new LaunchCommandSelection ("amd-radv-perftest", { "nggc,gpl" })
+        }, { LaunchOptionCapability.AMD });
+        assert (!invalid.is_valid);
+        assert_code (invalid, LaunchCommandCompositionDiagnosticCode.UNSUPPORTED_SELECTABLE_VALUE);
     }
 
     private void test_current_custom_proton_options () {

--- a/tests/launch-command-composer-test.vala
+++ b/tests/launch-command-composer-test.vala
@@ -160,7 +160,7 @@ namespace AppTests.LaunchCommandComposerTest {
             new LaunchCommandSelection ("amd-radv-perftest", { "nggc,rtcps" })
         }, { LaunchOptionCapability.AMD });
         assert (radv.is_valid);
-        assert (radv.launch_line == "RADV_PERFTEST=nggc,rtcps %command%");
+        assert (radv.launch_line == "RADV_PERFTEST='nggc,rtcps' %command%");
 
         var invalid = compose ({
             new LaunchCommandSelection ("amd-radv-perftest", { "nggc,gpl" })


### PR DESCRIPTION
## Summary

Fixes the launch-option failure reported in #1300.

The RADV performance-test widget was still exposing historical values such as `sam`, `gpl`, and `ruse`, while the semantic catalog only accepts the current Mesa RADV values. In addition, list-valued environment options such as `RADV_PERFTEST=nggc,rtcps` were being validated as one value instead of validating each comma-separated member.

## Changes

- synchronize the RADV performance-test UI with the catalog's supported values
- add explicit separator metadata for list-valued dynamic environment options
- validate each member of comma-separated RADV/ACO/VKD3D option lists
- add regression coverage for valid and invalid multi-value RADV selections
- surface composition diagnostics in Mass Edit instead of falling back immediately to the generic error message

## Expected result

Selections such as:

```
RADV_PERFTEST=nggc,rtcps
```

can be prepared and applied, while unsupported list members are still rejected with a useful diagnostic.

Fixes #1300